### PR TITLE
Use uint to store colors

### DIFF
--- a/MaterialColorUtilities.Maui.Tests/DynamicColorServiceTests.cs
+++ b/MaterialColorUtilities.Maui.Tests/DynamicColorServiceTests.cs
@@ -41,9 +41,9 @@ public class DynamicColorServiceTests
         
         Assert.IsTrue(dynamicColorService.EnableTheming);
         Assert.IsFalse(dynamicColorService.EnableDynamicColor);
-        Assert.AreEqual(unchecked((int)0xff4285F4), dynamicColorService.Seed);
-        Assert.AreEqual(unchecked((int)0xff005AC1), dynamicColorService.SchemeInt.Primary);
-        Assert.AreEqual(dynamicColorService.SchemeInt.Primary, dynamicColorService.SchemeMaui.Primary.ToInt());
+        Assert.AreEqual(0xff4285F4, dynamicColorService.Seed);
+        Assert.AreEqual(0xff005AC1, dynamicColorService.SchemeInt.Primary);
+        Assert.AreEqual(dynamicColorService.SchemeInt.Primary, dynamicColorService.SchemeMaui.Primary.ToUint());
         Assert.IsNotNull(_application.Resources[Schemes.Keys.Primary]);
     }
 
@@ -58,9 +58,9 @@ public class DynamicColorServiceTests
         
         Assert.IsTrue(dynamicColorService.EnableTheming);
         Assert.IsTrue(dynamicColorService.EnableDynamicColor);
-        Assert.AreEqual(unchecked((int)0xff4285F4), dynamicColorService.Seed);
-        Assert.AreEqual(unchecked((int)0xff005AC1), dynamicColorService.SchemeInt.Primary);
-        Assert.AreEqual(dynamicColorService.SchemeInt.Primary, dynamicColorService.SchemeMaui.Primary.ToInt());
+        Assert.AreEqual(0xff4285F4, dynamicColorService.Seed);
+        Assert.AreEqual(0xff005AC1, dynamicColorService.SchemeInt.Primary);
+        Assert.AreEqual(dynamicColorService.SchemeInt.Primary, dynamicColorService.SchemeMaui.Primary.ToUint());
         Assert.IsNotNull(_application.Resources[Schemes.Keys.Primary]);
     }
 
@@ -69,14 +69,14 @@ public class DynamicColorServiceTests
     {
         IOptions<DynamicColorOptions> options = CreateOptions();
 
-        ISeedColorService seedColorService = new MockSeedColorService(unchecked((int)0xFFc07d52));
+        ISeedColorService seedColorService = new MockSeedColorService(0xFFc07d52);
         DynamicColorService dynamicColorService = new(options, seedColorService, _application, _preferences);
         
         dynamicColorService.Initialize(null);
         
-        Assert.AreEqual(unchecked((int)0xFFc07d52), dynamicColorService.Seed);
-        Assert.AreEqual(unchecked((int)0xFF96490A), dynamicColorService.SchemeInt.Primary);
-        Assert.AreEqual(dynamicColorService.SchemeInt.Primary, dynamicColorService.SchemeMaui.Primary.ToInt());
+        Assert.AreEqual(0xFFc07d52, dynamicColorService.Seed);
+        Assert.AreEqual(0xFF96490A, dynamicColorService.SchemeInt.Primary);
+        Assert.AreEqual(dynamicColorService.SchemeInt.Primary, dynamicColorService.SchemeMaui.Primary.ToUint());
         Assert.IsNotNull(_application.Resources[Schemes.Keys.Primary]);
     }
 

--- a/MaterialColorUtilities.Maui.Tests/MockSeedColorService.cs
+++ b/MaterialColorUtilities.Maui.Tests/MockSeedColorService.cs
@@ -4,11 +4,11 @@ public class MockSeedColorService : ISeedColorService
 {
     public MockSeedColorService() { }
     
-    public MockSeedColorService(int? seedColor)
+    public MockSeedColorService(uint? seedColor)
     {
         SeedColor = seedColor;
     }
 
-    public int? SeedColor { get; }
+    public uint? SeedColor { get; }
     public event Action? OnSeedColorChanged { add { } remove { } }
 }

--- a/MaterialColorUtilities.Maui/DynamicColorOptions.cs
+++ b/MaterialColorUtilities.Maui/DynamicColorOptions.cs
@@ -20,7 +20,7 @@ public sealed class DynamicColorOptions
     /// <summary>
     /// Will be used if a dynamic seed color is not available or dynamic theming is disabled.
     /// </summary>
-    public int FallbackSeed { get; set; } = unchecked((int)0xff4285F4); // Google Blue
+    public uint FallbackSeed { get; set; } = 0xff4285F4; // Google Blue
 
     /// <summary>
     /// Whether to use wallpaper/accent color based dynamic theming. Defaults to true.

--- a/MaterialColorUtilities.Maui/DynamicColorService.cs
+++ b/MaterialColorUtilities.Maui/DynamicColorService.cs
@@ -11,7 +11,7 @@ namespace MaterialColorUtilities.Maui;
 // Fallback seed
 // Custom seed
 // Dynamic seed
-public class DynamicColorService : DynamicColorService<CorePalette, Scheme<int>, Scheme<Color>, LightSchemeMapper, DarkSchemeMapper>
+public class DynamicColorService : DynamicColorService<CorePalette, Scheme<uint>, Scheme<Color>, LightSchemeMapper, DarkSchemeMapper>
 {
     public DynamicColorService(IOptions<DynamicColorOptions> options, ISeedColorService seedColorService, IApplication application, IPreferences preferences) : base(options, seedColorService, application, preferences)
     {
@@ -29,7 +29,7 @@ public class DynamicColorService<
     TDarkSchemeMapper>
     : IMauiInitializeService
     where TCorePalette : CorePalette
-    where TSchemeInt : Scheme<int>, new()
+    where TSchemeInt : Scheme<uint>, new()
     where TSchemeMaui : Scheme<Color>, new()
     where TLightSchemeMapper : ISchemeMapper<TCorePalette, TSchemeInt>, new()
     where TDarkSchemeMapper : ISchemeMapper<TCorePalette, TSchemeInt>, new()
@@ -42,15 +42,15 @@ public class DynamicColorService<
     private readonly ResourceDictionary _appResources;
     private readonly IPreferences _preferences;
     private readonly bool _rememberIsDark;
-    private readonly int _fallbackSeed;
+    private readonly uint _fallbackSeed;
     
     private readonly TLightSchemeMapper _lightSchemeMapper = new();
     private readonly TDarkSchemeMapper _darkSchemeMapper = new();
 
     private bool _enableTheming;
     private bool _enableDynamicColor;
-    private int _seed;
-    private int? _prevSeed;
+    private uint _seed;
+    private uint? _prevSeed;
     private bool? _prevIsDark;
 
     public DynamicColorService(
@@ -93,7 +93,7 @@ public class DynamicColorService<
             if (!value)
             {
                 _seed = _preferences.ContainsKey(SeedKey)
-                    ? _preferences.Get(SeedKey, 0)
+                    ? (uint)_preferences.Get(SeedKey, 0)
                     : _fallbackSeed;
             }
 
@@ -112,14 +112,14 @@ public class DynamicColorService<
     /// <summary>
     /// A color in ARGB format, that is used as seed when creating the color scheme.
     /// </summary>
-    public int Seed
+    public uint Seed
     {
         get => _seed;
         set
         {
             if (value == _seed) return;
             _seed = value;
-            _preferences.Set(SeedKey, value);
+            _preferences.Set(SeedKey, (int)value);
             Update();
         }
     }
@@ -149,7 +149,7 @@ public class DynamicColorService<
         _seed = _fallbackSeed;
         
         if (_preferences.ContainsKey(SeedKey))
-            _seed = _preferences.Get(SeedKey, 0);
+            _seed = (uint)_preferences.Get(SeedKey, 0);
         
         _application.RequestedThemeChanged += (_, _) =>
         {
@@ -179,7 +179,7 @@ public class DynamicColorService<
         if (!EnableTheming) return;
 
         if (_enableDynamicColor && _seedColorService.SeedColor != null)
-            _seed = (int)_seedColorService.SeedColor;
+            _seed = (uint)_seedColorService.SeedColor;
         
         if (Seed != _prevSeed)
             CorePalette = CreateCorePalette(Seed);
@@ -196,7 +196,7 @@ public class DynamicColorService<
 
         if (typeof(TSchemeMaui) == typeof(Scheme<Color>))
         {
-            SchemeMaui = (TSchemeMaui)SchemeInt.ConvertTo(Color.FromInt);
+            SchemeMaui = (TSchemeMaui)SchemeInt.ConvertTo(Color.FromUint);
         }
         else
         {
@@ -206,7 +206,7 @@ public class DynamicColorService<
                 .Where(m => m.Name == nameof(Scheme<int>.ConvertTo))
                 .ToList()[0]
                 .MakeGenericMethod(typeof(Color))
-                .Invoke(SchemeInt, new object[] { (Func<int, Color>)Color.FromInt });
+                .Invoke(SchemeInt, new object[] { (Func<uint, Color>)Color.FromUint });
         }
 
 #if PLATFORM
@@ -234,7 +234,7 @@ public class DynamicColorService<
     /// If you replace CorePalette, make sure it has a constructor with the following parameters: <c>int seed, bool isContent</c>
     /// </remarks>
     // TODO: Replace with using empty constructor and method call
-    private static TCorePalette CreateCorePalette(int seed)
+    private static TCorePalette CreateCorePalette(uint seed)
     {
         return (TCorePalette)Activator.CreateInstance(typeof(TCorePalette), seed, false);
     }

--- a/MaterialColorUtilities.Maui/ISeedColorService.cs
+++ b/MaterialColorUtilities.Maui/ISeedColorService.cs
@@ -2,6 +2,6 @@
 
 public interface ISeedColorService
 {
-    int? SeedColor { get; }
+    uint? SeedColor { get; }
     event Action OnSeedColorChanged;
 }

--- a/MaterialColorUtilities.Maui/MauiAppBuilderExtensions.cs
+++ b/MaterialColorUtilities.Maui/MauiAppBuilderExtensions.cs
@@ -9,7 +9,7 @@ public static class MauiAppBuilderExtensions
         => builder.UseMaterialDynamicColors(_ => { });
 
     public static MauiAppBuilder UseMaterialDynamicColors(this MauiAppBuilder builder, uint fallbackSeed)
-        => builder.UseMaterialDynamicColors(opt => opt.FallbackSeed = (int)fallbackSeed);
+        => builder.UseMaterialDynamicColors(opt => opt.FallbackSeed = fallbackSeed);
 
     public static MauiAppBuilder UseMaterialDynamicColors(
         this MauiAppBuilder builder,
@@ -30,7 +30,7 @@ public static class MauiAppBuilderExtensions
         this MauiAppBuilder builder, uint fallbackSeed
     )
         where TDynamicColorService : class, IMauiInitializeService
-        => builder.UseMaterialDynamicColors<TDynamicColorService>(opt => opt.FallbackSeed = (int)fallbackSeed);
+        => builder.UseMaterialDynamicColors<TDynamicColorService>(opt => opt.FallbackSeed = fallbackSeed);
 
     public static MauiAppBuilder UseMaterialDynamicColors<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]

--- a/MaterialColorUtilities.Maui/SeedColorService.Mac.cs
+++ b/MaterialColorUtilities.Maui/SeedColorService.Mac.cs
@@ -18,7 +18,7 @@ public class SeedColorService : ISeedColorService
             null);
     }
     
-    public int? SeedColor
+    public uint? SeedColor
     {
         get
         {
@@ -30,9 +30,9 @@ public class SeedColorService : ISeedColorService
                 out NFloat b,
                 out NFloat _);
             return ColorUtils.ArgbFromRgb(
-                (int)(r * 255),
-                (int)(g * 255),
-                (int)(b * 255));
+                (uint)(r * 255),
+                (uint)(g * 255),
+                (uint)(b * 255));
         }
     }
 

--- a/MaterialColorUtilities.Maui/SeedColorService.Standard.cs
+++ b/MaterialColorUtilities.Maui/SeedColorService.Standard.cs
@@ -2,6 +2,6 @@
 
 public class SeedColorService : ISeedColorService
 {
-    public int? SeedColor => null;
+    public uint? SeedColor => null;
     public event Action OnSeedColorChanged{ add { } remove { } }
 }

--- a/MaterialColorUtilities.Maui/SeedColorService.Windows.cs
+++ b/MaterialColorUtilities.Maui/SeedColorService.Windows.cs
@@ -12,7 +12,7 @@ public class SeedColorService : ISeedColorService
         _uiSettings.ColorValuesChanged += (_, _) => OnSeedColorChanged?.Invoke();
     }
     
-    public int? SeedColor
+    public uint? SeedColor
     {
         get
         {

--- a/MaterialColorUtilities.Maui/SeedColorService.iOS.cs
+++ b/MaterialColorUtilities.Maui/SeedColorService.iOS.cs
@@ -2,6 +2,6 @@
 
 public class SeedColorService : ISeedColorService
 {
-    public int? SeedColor => null;
+    public uint? SeedColor => null;
     public event Action OnSeedColorChanged{ add { } remove { } }
 }

--- a/MaterialColorUtilities.Tests/BlenderTests.cs
+++ b/MaterialColorUtilities.Tests/BlenderTests.cs
@@ -21,10 +21,10 @@ namespace MaterialColorUtilities.Tests
     [TestClass]
     public class BlenderTests
     {
-        const int Red = unchecked((int)0xffff0000);
-        const int Blue = unchecked((int)0xff0000ff);
-        const int Green = unchecked((int)0xff00ff00);
-        const int Yellow = unchecked((int)0xffffff00);
+        const uint Red = 0xffff0000;
+        const uint Blue = 0xff0000ff;
+        const uint Green = 0xff00ff00;
+        const uint Yellow = 0xffffff00;
         
         [TestMethod]
         [DataRow(Red, Blue, 0xffFB0057)]
@@ -39,10 +39,10 @@ namespace MaterialColorUtilities.Tests
         [DataRow(Yellow, Blue, 0xffEBFFBA)]
         [DataRow(Yellow, Green, 0xffEBFFBA)]
         [DataRow(Yellow, Red, 0xffFFF6E3)]
-        public void Harmonize(int designColor, int sourceColor, uint result)
+        public void Harmonize(uint designColor, uint sourceColor, uint result)
         {
-            int answer = Blender.Harmonize(designColor, sourceColor);
-            Assert.AreEqual((int)result, answer);
+            uint answer = Blender.Harmonize(designColor, sourceColor);
+            Assert.AreEqual(result, answer);
         }
     }
 }

--- a/MaterialColorUtilities.Tests/ColorUtilsTests.cs
+++ b/MaterialColorUtilities.Tests/ColorUtilsTests.cs
@@ -46,9 +46,9 @@ namespace MaterialColorUtilities.Tests
             return Enumerable.Range(0, caseCount).Select(index => start + stepSize * index);
         }
 
-        private static IEnumerable<int> RgbRange => Enumerable.Range(0, 256 / 8).Select(x => x * 8);
+        private static IEnumerable<uint> RgbRange => Enumerable.Range(0, 256 / 8).Select(x => (uint)x * 8);
 
-        private static IEnumerable<int> FullRgbRange => Enumerable.Range(0, 256);
+        private static IEnumerable<uint> FullRgbRange => Enumerable.Range(0, 256).Select(x => (uint)x);
 
         [TestMethod]
         public void RangeIntegrity()
@@ -99,15 +99,15 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void RgbToXyzToRgb()
         {
-            foreach (int r in RgbRange)
+            foreach (uint r in RgbRange)
             {
-                foreach (int g in RgbRange)
+                foreach (uint g in RgbRange)
                 {
-                    foreach (int b in RgbRange)
+                    foreach (uint b in RgbRange)
                     {
-                        int argb = ColorUtils.ArgbFromRgb(r, g, b);
+                        uint argb = ColorUtils.ArgbFromRgb(r, g, b);
                         double[] xyz = ColorUtils.XyzFromArgb(argb);
-                        int converted = ColorUtils.ArgbFromXyz(xyz[0], xyz[1], xyz[2]);
+                        uint converted = ColorUtils.ArgbFromXyz(xyz[0], xyz[1], xyz[2]);
                         Assert.That.IsCloseTo(ColorUtils.RedFromArgb(converted), r, 1.5);
                         Assert.That.IsCloseTo(ColorUtils.GreenFromArgb(converted), g, 1.5);
                         Assert.That.IsCloseTo(ColorUtils.BlueFromArgb(converted), b, 1.5);
@@ -119,15 +119,15 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void RgbToLabToRgb()
         {
-            foreach (int r in RgbRange)
+            foreach (uint r in RgbRange)
             {
-                foreach (int g in RgbRange)
+                foreach (uint g in RgbRange)
                 {
-                    foreach (int b in RgbRange)
+                    foreach (uint b in RgbRange)
                     {
-                        int argb = ColorUtils.ArgbFromRgb(r, g, b);
+                        uint argb = ColorUtils.ArgbFromRgb(r, g, b);
                         double[] lab = ColorUtils.LabFromArgb(argb);
-                        int converted = ColorUtils.ArgbFromLab(lab[0], lab[1], lab[2]);
+                        uint converted = ColorUtils.ArgbFromLab(lab[0], lab[1], lab[2]);
                         Assert.That.IsCloseTo(ColorUtils.RedFromArgb(converted), r, 1.5);
                         Assert.That.IsCloseTo(ColorUtils.GreenFromArgb(converted), g, 1.5);
                         Assert.That.IsCloseTo(ColorUtils.BlueFromArgb(converted), b, 1.5);
@@ -139,11 +139,11 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void RgbToLStarToRgb()
         {
-            foreach (int component in FullRgbRange)
+            foreach (uint component in FullRgbRange)
             {
-                int argb = ColorUtils.ArgbFromRgb(component, component, component);
+                uint argb = ColorUtils.ArgbFromRgb(component, component, component);
                 double lStar = ColorUtils.LStarFromArgb(argb);
-                int converted = ColorUtils.ArgbFromLstar(lStar);
+                uint converted = ColorUtils.ArgbFromLstar(lStar);
                 Assert.AreEqual(converted, argb);
             }
         }
@@ -151,9 +151,9 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void LinearizeDelinearize()
         {
-            foreach (int rgbComponent in FullRgbRange)
+            foreach (uint rgbComponent in FullRgbRange)
             {
-                int converted = ColorUtils.Delinearized(ColorUtils.Linearized(rgbComponent));
+                uint converted = ColorUtils.Delinearized(ColorUtils.Linearized(rgbComponent));
                 Assert.AreEqual(converted, rgbComponent);
             }
         }

--- a/MaterialColorUtilities.Tests/HctTests.cs
+++ b/MaterialColorUtilities.Tests/HctTests.cs
@@ -26,18 +26,18 @@ namespace MaterialColorUtilities.Tests
     [TestClass]
     public class HctTests
     {
-        const int Black = unchecked((int)0xff000000);
-        const int White = unchecked((int)0xffffffff);
-        const int Red = unchecked((int)0xffff0000);
-        const int Green = unchecked((int)0xff00ff00);
-        const int Blue = unchecked((int)0xff0000ff);
-        const int Midgray = unchecked((int)0xff777777);
+        const uint Black = 0xff000000;
+        const uint White = 0xffffffff;
+        const uint Red = 0xffff0000;
+        const uint Green = 0xff00ff00;
+        const uint Blue = 0xff0000ff;
+        const uint Midgray = 0xff777777;
 
         [TestMethod]
         public void Conversions_AreReflexive()
         {
             Cam16 cam = Cam16.FromInt(Red);
-            int color = cam.Viewed(ViewingConditions.Default);
+            uint color = cam.Viewed(ViewingConditions.Default);
             Assert.AreEqual(color, Red);
         }
 
@@ -125,10 +125,10 @@ namespace MaterialColorUtilities.Tests
         [DataRow(Blue)]
         [DataRow(White)]
         [DataRow(Midgray)]
-        public void RgbToCamToRgb(int colorToTest)
+        public void RgbToCamToRgb(uint colorToTest)
         {
             Cam16 cam = Cam16.FromInt(colorToTest);
-            int color = Hct.From(cam.Hue, cam.Chroma, ColorUtils.LStarFromArgb(colorToTest))
+            uint color = Hct.From(cam.Hue, cam.Chroma, ColorUtils.LStarFromArgb(colorToTest))
                 .ToInt();
             Assert.AreEqual(colorToTest, color);
         }
@@ -181,10 +181,10 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void Hct_PreservesOriginalColor()
         {
-            for (int argb = unchecked((int)0xFF000000); argb <= unchecked((int)0xFFFFFFFF); argb += 6969)
+            for (uint argb = 0xFF000000; argb < 0xFFFFFFFF - 6969; argb += 6969)
             {
                 Hct hct = Hct.FromInt(argb);
-                int reconstructedArgb = Hct.From(hct.Hue, hct.Chroma, hct.Tone).ToInt();
+                uint reconstructedArgb = Hct.From(hct.Hue, hct.Chroma, hct.Tone).ToInt();
                 Assert.AreEqual(argb, reconstructedArgb);
             }
         }
@@ -192,13 +192,13 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void Hct_ReturnsSufficientlyCloseColor()
         {
-            for (var hue = 15; hue < 360; hue += 30)
+            for (int hue = 15; hue < 360; hue += 30)
             {
-                for (var chroma = 0; chroma <= 100; chroma += 10)
+                for (int chroma = 0; chroma <= 100; chroma += 10)
                 {
-                    for (var tone = 20; tone <= 80; tone += 10)
+                    for (int tone = 20; tone <= 80; tone += 10)
                     {
-                        var hctColor = Hct.From(hue, chroma, tone);
+                        Hct hctColor = Hct.From(hue, chroma, tone);
                         if (chroma > 0)
                             Assert.That.IsCloseTo(hctColor.Hue, hue, 4.0);
                         Assert.That.IsInInclusiveRange(hctColor.Chroma, 0.0, chroma + 2.5);

--- a/MaterialColorUtilities.Tests/ImageUtilsTests.cs
+++ b/MaterialColorUtilities.Tests/ImageUtilsTests.cs
@@ -15,8 +15,8 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void ColorfulImage()
         {
-            int[] image = Resources.LoadImage("sandy-desert.webp");
-            int resultColor = ImageUtils.ColorsFromImage(image)[0];
+            uint[] image = Resources.LoadImage("sandy-desert.webp");
+            uint resultColor = ImageUtils.ColorsFromImage(image)[0];
             Assert.AreNotEqual(Scorer.Default, resultColor);
         }
 
@@ -27,8 +27,8 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void BoringImage()
         {
-            int[] image = Resources.LoadImage("black-rectangle-on-white-background.jpg");
-            int resultColor = ImageUtils.ColorsFromImage(image)[0];
+            uint[] image = Resources.LoadImage("black-rectangle-on-white-background.jpg");
+            uint resultColor = ImageUtils.ColorsFromImage(image)[0];
             Assert.AreEqual(Scorer.Default, resultColor);
         }
     }

--- a/MaterialColorUtilities.Tests/PalettesTests.cs
+++ b/MaterialColorUtilities.Tests/PalettesTests.cs
@@ -25,82 +25,82 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void TonalPalette_OfBlue()
         {
-            Hct hct = Hct.FromInt(unchecked((int)0xff0000ff));
+            Hct hct = Hct.FromInt(0xff0000ff);
             TonalPalette tones = TonalPalette.FromHueAndChroma(hct.Hue, hct.Chroma);
-            Assert.AreEqual(unchecked((int)0xff000000), tones[0]);
-            Assert.AreEqual(unchecked((int)0xff00003c), tones[3]);
-            Assert.AreEqual(unchecked((int)0xff00006e), tones[10]);
-            Assert.AreEqual(unchecked((int)0xff0001ac), tones[20]);
-            Assert.AreEqual(unchecked((int)0xff0000ef), tones[30]);
-            Assert.AreEqual(unchecked((int)0xff343dff), tones[40]);
-            Assert.AreEqual(unchecked((int)0xff5a64ff), tones[50]);
-            Assert.AreEqual(unchecked((int)0xff7c84ff), tones[60]);
-            Assert.AreEqual(unchecked((int)0xff9da3ff), tones[70]);
-            Assert.AreEqual(unchecked((int)0xffbec2ff), tones[80]);
-            Assert.AreEqual(unchecked((int)0xffe0e0ff), tones[90]);
-            Assert.AreEqual(unchecked((int)0xfff1efff), tones[95]);
-            Assert.AreEqual(unchecked((int)0xfffffbff), tones[99]);
-            Assert.AreEqual(unchecked((int)0xffffffff), tones[100]);
+            Assert.AreEqual(0xff000000, tones[0]);
+            Assert.AreEqual(0xff00003c, tones[3]);
+            Assert.AreEqual(0xff00006e, tones[10]);
+            Assert.AreEqual(0xff0001ac, tones[20]);
+            Assert.AreEqual(0xff0000ef, tones[30]);
+            Assert.AreEqual(0xff343dff, tones[40]);
+            Assert.AreEqual(0xff5a64ff, tones[50]);
+            Assert.AreEqual(0xff7c84ff, tones[60]);
+            Assert.AreEqual(0xff9da3ff, tones[70]);
+            Assert.AreEqual(0xffbec2ff, tones[80]);
+            Assert.AreEqual(0xffe0e0ff, tones[90]);
+            Assert.AreEqual(0xfff1efff, tones[95]);
+            Assert.AreEqual(0xfffffbff, tones[99]);
+            Assert.AreEqual(0xffffffff, tones[100]);
         }
 
         [TestMethod]
         public void CorePalette_Of_Blue()
         {
-            CorePalette core = CorePalette.Of(unchecked((int)0xff0000ff));
-            Assert.AreEqual(unchecked((int)0xffffffff), core.Primary[100]);
-            Assert.AreEqual(unchecked((int)0xfff1efff), core.Primary[95]);
-            Assert.AreEqual(unchecked((int)0xffe0e0ff), core.Primary[90]);
-            Assert.AreEqual(unchecked((int)0xffbec2ff), core.Primary[80]);
-            Assert.AreEqual(unchecked((int)0xff9da3ff), core.Primary[70]);
-            Assert.AreEqual(unchecked((int)0xff7c84ff), core.Primary[60]);
-            Assert.AreEqual(unchecked((int)0xff5a64ff), core.Primary[50]);
-            Assert.AreEqual(unchecked((int)0xff343dff), core.Primary[40]);
-            Assert.AreEqual(unchecked((int)0xff0000ef), core.Primary[30]);
-            Assert.AreEqual(unchecked((int)0xff0001ac), core.Primary[20]);
-            Assert.AreEqual(unchecked((int)0xff00006e), core.Primary[10]);
-            Assert.AreEqual(unchecked((int)0xff000000), core.Primary[0]);
-            Assert.AreEqual(unchecked((int)0xffffffff), core.Secondary[100]);
-            Assert.AreEqual(unchecked((int)0xfff1efff), core.Secondary[95]);
-            Assert.AreEqual(unchecked((int)0xffe1e0f9), core.Secondary[90]);
-            Assert.AreEqual(unchecked((int)0xffc5c4dd), core.Secondary[80]);
-            Assert.AreEqual(unchecked((int)0xffa9a9c1), core.Secondary[70]);
-            Assert.AreEqual(unchecked((int)0xff8f8fa6), core.Secondary[60]);
-            Assert.AreEqual(unchecked((int)0xff75758b), core.Secondary[50]);
-            Assert.AreEqual(unchecked((int)0xff5c5d72), core.Secondary[40]);
-            Assert.AreEqual(unchecked((int)0xff444559), core.Secondary[30]);
-            Assert.AreEqual(unchecked((int)0xff2e2f42), core.Secondary[20]);
-            Assert.AreEqual(unchecked((int)0xff191a2c), core.Secondary[10]);
-            Assert.AreEqual(unchecked((int)0xff000000), core.Secondary[0]);
+            CorePalette core = CorePalette.Of(0xff0000ff);
+            Assert.AreEqual(0xffffffff, core.Primary[100]);
+            Assert.AreEqual(0xfff1efff, core.Primary[95]);
+            Assert.AreEqual(0xffe0e0ff, core.Primary[90]);
+            Assert.AreEqual(0xffbec2ff, core.Primary[80]);
+            Assert.AreEqual(0xff9da3ff, core.Primary[70]);
+            Assert.AreEqual(0xff7c84ff, core.Primary[60]);
+            Assert.AreEqual(0xff5a64ff, core.Primary[50]);
+            Assert.AreEqual(0xff343dff, core.Primary[40]);
+            Assert.AreEqual(0xff0000ef, core.Primary[30]);
+            Assert.AreEqual(0xff0001ac, core.Primary[20]);
+            Assert.AreEqual(0xff00006e, core.Primary[10]);
+            Assert.AreEqual(0xff000000, core.Primary[0]);
+            Assert.AreEqual(0xffffffff, core.Secondary[100]);
+            Assert.AreEqual(0xfff1efff, core.Secondary[95]);
+            Assert.AreEqual(0xffe1e0f9, core.Secondary[90]);
+            Assert.AreEqual(0xffc5c4dd, core.Secondary[80]);
+            Assert.AreEqual(0xffa9a9c1, core.Secondary[70]);
+            Assert.AreEqual(0xff8f8fa6, core.Secondary[60]);
+            Assert.AreEqual(0xff75758b, core.Secondary[50]);
+            Assert.AreEqual(0xff5c5d72, core.Secondary[40]);
+            Assert.AreEqual(0xff444559, core.Secondary[30]);
+            Assert.AreEqual(0xff2e2f42, core.Secondary[20]);
+            Assert.AreEqual(0xff191a2c, core.Secondary[10]);
+            Assert.AreEqual(0xff000000, core.Secondary[0]);
         }
 
         [TestMethod]
         public void CorePalette_ContentOf_Blue()
         {
-            CorePalette core = CorePalette.ContentOf(unchecked((int)0xff0000ff));
-            Assert.AreEqual(unchecked((int)0xffffffff), core.Primary[100]);
-            Assert.AreEqual(unchecked((int)0xfff1efff), core.Primary[95]);
-            Assert.AreEqual(unchecked((int)0xffe0e0ff), core.Primary[90]);
-            Assert.AreEqual(unchecked((int)0xffbec2ff), core.Primary[80]);
-            Assert.AreEqual(unchecked((int)0xff9da3ff), core.Primary[70]);
-            Assert.AreEqual(unchecked((int)0xff7c84ff), core.Primary[60]);
-            Assert.AreEqual(unchecked((int)0xff5a64ff), core.Primary[50]);
-            Assert.AreEqual(unchecked((int)0xff343dff), core.Primary[40]);
-            Assert.AreEqual(unchecked((int)0xff0000ef), core.Primary[30]);
-            Assert.AreEqual(unchecked((int)0xff0001ac), core.Primary[20]);
-            Assert.AreEqual(unchecked((int)0xff00006e), core.Primary[10]);
-            Assert.AreEqual(unchecked((int)0xff000000), core.Primary[0]);
-            Assert.AreEqual(unchecked((int)0xffffffff), core.Secondary[100]);
-            Assert.AreEqual(unchecked((int)0xfff1efff), core.Secondary[95]);
-            Assert.AreEqual(unchecked((int)0xffe0e0ff), core.Secondary[90]);
-            Assert.AreEqual(unchecked((int)0xffc1c3f4), core.Secondary[80]);
-            Assert.AreEqual(unchecked((int)0xffa5a7d7), core.Secondary[70]);
-            Assert.AreEqual(unchecked((int)0xff8b8dbb), core.Secondary[60]);
-            Assert.AreEqual(unchecked((int)0xff7173a0), core.Secondary[50]);
-            Assert.AreEqual(unchecked((int)0xff585b86), core.Secondary[40]);
-            Assert.AreEqual(unchecked((int)0xff40436d), core.Secondary[30]);
-            Assert.AreEqual(unchecked((int)0xff2a2d55), core.Secondary[20]);
-            Assert.AreEqual(unchecked((int)0xff14173f), core.Secondary[10]);
-            Assert.AreEqual(unchecked((int)0xff000000), core.Secondary[0]);
+            CorePalette core = CorePalette.ContentOf(0xff0000ff);
+            Assert.AreEqual(0xffffffff, core.Primary[100]);
+            Assert.AreEqual(0xfff1efff, core.Primary[95]);
+            Assert.AreEqual(0xffe0e0ff, core.Primary[90]);
+            Assert.AreEqual(0xffbec2ff, core.Primary[80]);
+            Assert.AreEqual(0xff9da3ff, core.Primary[70]);
+            Assert.AreEqual(0xff7c84ff, core.Primary[60]);
+            Assert.AreEqual(0xff5a64ff, core.Primary[50]);
+            Assert.AreEqual(0xff343dff, core.Primary[40]);
+            Assert.AreEqual(0xff0000ef, core.Primary[30]);
+            Assert.AreEqual(0xff0001ac, core.Primary[20]);
+            Assert.AreEqual(0xff00006e, core.Primary[10]);
+            Assert.AreEqual(0xff000000, core.Primary[0]);
+            Assert.AreEqual(0xffffffff, core.Secondary[100]);
+            Assert.AreEqual(0xfff1efff, core.Secondary[95]);
+            Assert.AreEqual(0xffe0e0ff, core.Secondary[90]);
+            Assert.AreEqual(0xffc1c3f4, core.Secondary[80]);
+            Assert.AreEqual(0xffa5a7d7, core.Secondary[70]);
+            Assert.AreEqual(0xff8b8dbb, core.Secondary[60]);
+            Assert.AreEqual(0xff7173a0, core.Secondary[50]);
+            Assert.AreEqual(0xff585b86, core.Secondary[40]);
+            Assert.AreEqual(0xff40436d, core.Secondary[30]);
+            Assert.AreEqual(0xff2a2d55, core.Secondary[20]);
+            Assert.AreEqual(0xff14173f, core.Secondary[10]);
+            Assert.AreEqual(0xff000000, core.Secondary[0]);
         }        
     }
 }

--- a/MaterialColorUtilities.Tests/QuantizerCelebiTests.cs
+++ b/MaterialColorUtilities.Tests/QuantizerCelebiTests.cs
@@ -24,10 +24,10 @@ namespace MaterialColorUtilities.Tests
     [TestClass]
     public class QuantizerCelebiTests
     {
-        const int Red = unchecked((int)0xFFFF0000);
-        const int Green = unchecked((int)0xFF00FF00);
-        const int Blue = unchecked((int)0xFF0000FF);
-        const int MaxColors = 256;
+        const uint Red = 0xFFFF0000;
+        const uint Green = 0xFF00FF00;
+        const uint Blue = 0xFF0000FF;
+        const uint MaxColors = 256;
         
         [TestMethod]
         [DataRow(new[] { Red }, new[] { Red }, DisplayName = "1R")]
@@ -42,10 +42,10 @@ namespace MaterialColorUtilities.Tests
         [DataRow(new[] { Red, Red, Green, Green, Green },
                  new[] { Green, Red},
                  DisplayName = "2R 3G")]
-        public void Quantize(int[] pixels, int[] expected)
+        public void Quantize(uint[] pixels, uint[] expected)
         {
-            Dictionary<int, int> result = QuantizerCelebi.Quantize(pixels, MaxColors);
-            int[] colors = result.Keys.ToArray();
+            Dictionary<uint, uint> result = QuantizerCelebi.Quantize(pixels, MaxColors);
+            uint[] colors = result.Keys.ToArray();
             Assert.AreEqual(expected.Length, colors.Length);
             Assert.That.AreSequenceEqual(expected, colors);
         }

--- a/MaterialColorUtilities.Tests/QuantizerWsmeansTests.cs
+++ b/MaterialColorUtilities.Tests/QuantizerWsmeansTests.cs
@@ -25,11 +25,11 @@ namespace MaterialColorUtilities.Tests
     [TestClass]
     public class QuantizerWsmeansTests
     {
-        const int Red = unchecked((int)0xFFFF0000);
-        const int Green = unchecked((int)0xFF00FF00);
-        const int Blue = unchecked((int)0xFF0000FF);
-        const int Random = unchecked((int)0xff426088);
-        const int MaxColors = 256;
+        const uint Red = 0xFFFF0000;
+        const uint Green = 0xFF00FF00;
+        const uint Blue = 0xFF0000FF;
+        const uint Random = 0xff426088;
+        const uint MaxColors = 256;
 
         [TestMethod]
         [DataRow(new[] { Random }, new[] { Random }, DisplayName = "1Rando")]
@@ -37,10 +37,10 @@ namespace MaterialColorUtilities.Tests
         [DataRow(new[] { Green }, new[] { Green }, DisplayName = "1G")]
         [DataRow(new[] { Blue }, new[] { Blue }, DisplayName = "1B")]
         [DataRow(new[] { Blue, Blue, Blue, Blue, Blue }, new[] { Blue }, DisplayName = "5B")]
-        public void Quantize(int[] pixels, int[] expected)
+        public void Quantize(uint[] pixels, uint[] expected)
         {
-            Dictionary<int, int> result = QuantizerWsmeans.Quantize(pixels, Array.Empty<int>(), MaxColors);
-            int[] colors = result.Keys.ToArray();
+            Dictionary<uint, uint> result = QuantizerWsmeans.Quantize(pixels, Array.Empty<uint>(), MaxColors);
+            uint[] colors = result.Keys.ToArray();
             Assert.AreEqual(expected.Length, colors.Length);
             Assert.That.AreSequenceEqual(expected, colors);
         }

--- a/MaterialColorUtilities.Tests/QuantizerWuTests.cs
+++ b/MaterialColorUtilities.Tests/QuantizerWuTests.cs
@@ -23,11 +23,11 @@ namespace MaterialColorUtilities.Tests
     [TestClass]
     public class QuantizerWuTests
     {
-        private const int Red = unchecked((int)0xffff0000);
-        private const int Green = unchecked((int)0xff00ff00);
-        private const int Blue = unchecked((int)0xff0000ff);
-        private const int Random = unchecked((int)0xff426088);
-        private const int MaxColors = 256;
+        private const uint Red = 0xffff0000;
+        private const uint Green = 0xff00ff00;
+        private const uint Blue = 0xff0000ff;
+        private const uint Random = 0xff426088;
+        private const uint MaxColors = 256;
 
         [TestMethod]
         [DataRow(new[] { Random }, new[] { Random }, DisplayName = "1Random")]
@@ -37,11 +37,11 @@ namespace MaterialColorUtilities.Tests
         [DataRow(new[] { Blue, Blue, Blue, Blue, Blue }, new[] { Blue }, DisplayName = "5B")]
         [DataRow(new[] { Red, Red, Green, Green, Green }, new[] { Green, Red }, DisplayName = "2R 3G")]
         [DataRow(new[] { Red, Green, Blue }, new[] { Blue, Red, Green }, DisplayName = "1R 1G 1B")]
-        public void Quantize(int[] pixels, int[] expected)
+        public void Quantize(uint[] pixels, uint[] expected)
         {
             QuantizerWu quantizer = new();
-            var result = quantizer.Quantize(pixels, MaxColors);
-            int[] colors = result.ColorToCount.Keys.ToArray();
+            QuantizerResult result = quantizer.Quantize(pixels, MaxColors);
+            uint[] colors = result.ColorToCount.Keys.ToArray();
             Assert.AreEqual(expected.Length, colors.Length);
             Assert.That.AreSequenceEqual(expected, colors);
         }

--- a/MaterialColorUtilities.Tests/SchemeTests.cs
+++ b/MaterialColorUtilities.Tests/SchemeTests.cs
@@ -25,169 +25,169 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void BlueLight()
         {
-            Scheme<int> scheme = new LightSchemeMapper().Map(new(unchecked((int)0xff0000ff)));
-            Assert.AreEqual(unchecked((int)0xff343DFF), scheme.Primary);
+            Scheme<uint> scheme = new LightSchemeMapper().Map(new(0xff0000ff));
+            Assert.AreEqual(0xff343DFF, scheme.Primary);
         }
 
         [TestMethod]
         public void BlueDark()
         {
-            Scheme<int> scheme = new DarkSchemeMapper().Map(new(unchecked((int)0xff0000ff)));
-            Assert.AreEqual(unchecked((int)0xffBEC2FF), scheme.Primary);
+            Scheme<uint> scheme = new DarkSchemeMapper().Map(new(0xff0000ff));
+            Assert.AreEqual(0xffBEC2FF, scheme.Primary);
         }
 
         [TestMethod]
         public void PurpleishLight()
         {
-            Scheme<int> scheme = new LightSchemeMapper().Map(new(unchecked((int)0xff6750A4)));
-            Assert.AreEqual(unchecked((int)0xff6750A4), scheme.Primary);
-            Assert.AreEqual(unchecked((int)0xff625B71), scheme.Secondary);
-            Assert.AreEqual(unchecked((int)0xff7E5260), scheme.Tertiary);
-            Assert.AreEqual(unchecked((int)0xffFFFBFF), scheme.Surface);
-            Assert.AreEqual(unchecked((int)0xff1C1B1E), scheme.OnSurface);
+            Scheme<uint> scheme = new LightSchemeMapper().Map(new(0xff6750A4));
+            Assert.AreEqual(0xff6750A4, scheme.Primary);
+            Assert.AreEqual(0xff625B71, scheme.Secondary);
+            Assert.AreEqual(0xff7E5260, scheme.Tertiary);
+            Assert.AreEqual(0xffFFFBFF, scheme.Surface);
+            Assert.AreEqual(0xff1C1B1E, scheme.OnSurface);
         }
 
         [TestMethod]
         public void PurpleishDark()
         {
-            Scheme<int> scheme = new DarkSchemeMapper().Map(new(unchecked((int)0xff6750A4)));
-            Assert.AreEqual(unchecked((int)0xffCFBCFF), scheme.Primary);
-            Assert.AreEqual(unchecked((int)0xffCBC2DB), scheme.Secondary);
-            Assert.AreEqual(unchecked((int)0xffEFB8C8), scheme.Tertiary);
-            Assert.AreEqual(unchecked((int)0xff1c1b1e), scheme.Surface);
-            Assert.AreEqual(unchecked((int)0xffE6E1E6), scheme.OnSurface);
+            Scheme<uint> scheme = new DarkSchemeMapper().Map(new(0xff6750A4));
+            Assert.AreEqual(0xffCFBCFF, scheme.Primary);
+            Assert.AreEqual(0xffCBC2DB, scheme.Secondary);
+            Assert.AreEqual(0xffEFB8C8, scheme.Tertiary);
+            Assert.AreEqual(0xff1c1b1e, scheme.Surface);
+            Assert.AreEqual(0xffE6E1E6, scheme.OnSurface);
         }
 
         [TestMethod]
         public void LightSchemeFromHighChromaColor()
         {
-            Scheme<int> scheme = new LightSchemeMapper().Map(new(unchecked((int)0xfffa2bec)));
-            Assert.AreEqual(unchecked((int)0xffab00a2), scheme.Primary);
-            Assert.AreEqual(unchecked((int)0xffffffff), scheme.OnPrimary);
-            Assert.AreEqual(unchecked((int)0xffffd7f3), scheme.PrimaryContainer);
-            Assert.AreEqual(unchecked((int)0xff390035), scheme.OnPrimaryContainer);
-            Assert.AreEqual(unchecked((int)0xff6e5868), scheme.Secondary);
-            Assert.AreEqual(unchecked((int)0xffffffff), scheme.OnSecondary);
-            Assert.AreEqual(unchecked((int)0xfff8daee), scheme.SecondaryContainer);
-            Assert.AreEqual(unchecked((int)0xff271624), scheme.OnSecondaryContainer);
-            Assert.AreEqual(unchecked((int)0xff815343), scheme.Tertiary);
-            Assert.AreEqual(unchecked((int)0xffffffff), scheme.OnTertiary);
-            Assert.AreEqual(unchecked((int)0xffffdbd0), scheme.TertiaryContainer);
-            Assert.AreEqual(unchecked((int)0xff321207), scheme.OnTertiaryContainer);
-            Assert.AreEqual(unchecked((int)0xffba1a1a), scheme.Error);
-            Assert.AreEqual(unchecked((int)0xffffffff), scheme.OnError);
-            Assert.AreEqual(unchecked((int)0xffffdad6), scheme.ErrorContainer);
-            Assert.AreEqual(unchecked((int)0xff410002), scheme.OnErrorContainer);
-            Assert.AreEqual(unchecked((int)0xfffffbff), scheme.Background);
-            Assert.AreEqual(unchecked((int)0xff1f1a1d), scheme.OnBackground);
-            Assert.AreEqual(unchecked((int)0xfffffbff), scheme.Surface);
-            Assert.AreEqual(unchecked((int)0xff1f1a1d), scheme.OnSurface);
-            Assert.AreEqual(unchecked((int)0xffeedee7), scheme.SurfaceVariant);
-            Assert.AreEqual(unchecked((int)0xff4e444b), scheme.OnSurfaceVariant);
-            Assert.AreEqual(unchecked((int)0xff80747b), scheme.Outline);
-            Assert.AreEqual(unchecked((int)0xff000000), scheme.Shadow);
-            Assert.AreEqual(unchecked((int)0xff342f32), scheme.InverseSurface);
-            Assert.AreEqual(unchecked((int)0xfff8eef2), scheme.InverseOnSurface);
-            Assert.AreEqual(unchecked((int)0xffffabee), scheme.InversePrimary);
+            Scheme<uint> scheme = new LightSchemeMapper().Map(new(0xfffa2bec));
+            Assert.AreEqual(0xffab00a2, scheme.Primary);
+            Assert.AreEqual(0xffffffff, scheme.OnPrimary);
+            Assert.AreEqual(0xffffd7f3, scheme.PrimaryContainer);
+            Assert.AreEqual(0xff390035, scheme.OnPrimaryContainer);
+            Assert.AreEqual(0xff6e5868, scheme.Secondary);
+            Assert.AreEqual(0xffffffff, scheme.OnSecondary);
+            Assert.AreEqual(0xfff8daee, scheme.SecondaryContainer);
+            Assert.AreEqual(0xff271624, scheme.OnSecondaryContainer);
+            Assert.AreEqual(0xff815343, scheme.Tertiary);
+            Assert.AreEqual(0xffffffff, scheme.OnTertiary);
+            Assert.AreEqual(0xffffdbd0, scheme.TertiaryContainer);
+            Assert.AreEqual(0xff321207, scheme.OnTertiaryContainer);
+            Assert.AreEqual(0xffba1a1a, scheme.Error);
+            Assert.AreEqual(0xffffffff, scheme.OnError);
+            Assert.AreEqual(0xffffdad6, scheme.ErrorContainer);
+            Assert.AreEqual(0xff410002, scheme.OnErrorContainer);
+            Assert.AreEqual(0xfffffbff, scheme.Background);
+            Assert.AreEqual(0xff1f1a1d, scheme.OnBackground);
+            Assert.AreEqual(0xfffffbff, scheme.Surface);
+            Assert.AreEqual(0xff1f1a1d, scheme.OnSurface);
+            Assert.AreEqual(0xffeedee7, scheme.SurfaceVariant);
+            Assert.AreEqual(0xff4e444b, scheme.OnSurfaceVariant);
+            Assert.AreEqual(0xff80747b, scheme.Outline);
+            Assert.AreEqual(0xff000000, scheme.Shadow);
+            Assert.AreEqual(0xff342f32, scheme.InverseSurface);
+            Assert.AreEqual(0xfff8eef2, scheme.InverseOnSurface);
+            Assert.AreEqual(0xffffabee, scheme.InversePrimary);
         }
 
         [TestMethod]
         public void DarkSchemeFromHighChromaColor()
         {
-            Scheme<int> scheme = new DarkSchemeMapper().Map(new(unchecked((int)0xfffa2bec)));
-            Assert.AreEqual(unchecked((int)0xffffabee), scheme.Primary);
-            Assert.AreEqual(unchecked((int)0xff5c0057), scheme.OnPrimary);
-            Assert.AreEqual(unchecked((int)0xff83007b), scheme.PrimaryContainer);
-            Assert.AreEqual(unchecked((int)0xffffd7f3), scheme.OnPrimaryContainer);
-            Assert.AreEqual(unchecked((int)0xffdbbed1), scheme.Secondary);
-            Assert.AreEqual(unchecked((int)0xff3e2a39), scheme.OnSecondary);
-            Assert.AreEqual(unchecked((int)0xff554050), scheme.SecondaryContainer);
-            Assert.AreEqual(unchecked((int)0xfff8daee), scheme.OnSecondaryContainer);
-            Assert.AreEqual(unchecked((int)0xfff5b9a5), scheme.Tertiary);
-            Assert.AreEqual(unchecked((int)0xff4c2619), scheme.OnTertiary);
-            Assert.AreEqual(unchecked((int)0xff663c2d), scheme.TertiaryContainer);
-            Assert.AreEqual(unchecked((int)0xffffdbd0), scheme.OnTertiaryContainer);
-            Assert.AreEqual(unchecked((int)0xffffb4ab), scheme.Error);
-            Assert.AreEqual(unchecked((int)0xff690005), scheme.OnError);
-            Assert.AreEqual(unchecked((int)0xff93000a), scheme.ErrorContainer);
-            Assert.AreEqual(unchecked((int)0xffffb4ab), scheme.OnErrorContainer);
-            Assert.AreEqual(unchecked((int)0xff1f1a1d), scheme.Background);
-            Assert.AreEqual(unchecked((int)0xffeae0e4), scheme.OnBackground);
-            Assert.AreEqual(unchecked((int)0xff1f1a1d), scheme.Surface);
-            Assert.AreEqual(unchecked((int)0xffeae0e4), scheme.OnSurface);
-            Assert.AreEqual(unchecked((int)0xff4e444b), scheme.SurfaceVariant);
-            Assert.AreEqual(unchecked((int)0xffd2c2cb), scheme.OnSurfaceVariant);
-            Assert.AreEqual(unchecked((int)0xff9a8d95), scheme.Outline);
-            Assert.AreEqual(unchecked((int)0xff000000), scheme.Shadow);
-            Assert.AreEqual(unchecked((int)0xffeae0e4), scheme.InverseSurface);
-            Assert.AreEqual(unchecked((int)0xff342f32), scheme.InverseOnSurface);
-            Assert.AreEqual(unchecked((int)0xffab00a2), scheme.InversePrimary);
+            Scheme<uint> scheme = new DarkSchemeMapper().Map(new(0xfffa2bec));
+            Assert.AreEqual(0xffffabee, scheme.Primary);
+            Assert.AreEqual(0xff5c0057, scheme.OnPrimary);
+            Assert.AreEqual(0xff83007b, scheme.PrimaryContainer);
+            Assert.AreEqual(0xffffd7f3, scheme.OnPrimaryContainer);
+            Assert.AreEqual(0xffdbbed1, scheme.Secondary);
+            Assert.AreEqual(0xff3e2a39, scheme.OnSecondary);
+            Assert.AreEqual(0xff554050, scheme.SecondaryContainer);
+            Assert.AreEqual(0xfff8daee, scheme.OnSecondaryContainer);
+            Assert.AreEqual(0xfff5b9a5, scheme.Tertiary);
+            Assert.AreEqual(0xff4c2619, scheme.OnTertiary);
+            Assert.AreEqual(0xff663c2d, scheme.TertiaryContainer);
+            Assert.AreEqual(0xffffdbd0, scheme.OnTertiaryContainer);
+            Assert.AreEqual(0xffffb4ab, scheme.Error);
+            Assert.AreEqual(0xff690005, scheme.OnError);
+            Assert.AreEqual(0xff93000a, scheme.ErrorContainer);
+            Assert.AreEqual(0xffffb4ab, scheme.OnErrorContainer);
+            Assert.AreEqual(0xff1f1a1d, scheme.Background);
+            Assert.AreEqual(0xffeae0e4, scheme.OnBackground);
+            Assert.AreEqual(0xff1f1a1d, scheme.Surface);
+            Assert.AreEqual(0xffeae0e4, scheme.OnSurface);
+            Assert.AreEqual(0xff4e444b, scheme.SurfaceVariant);
+            Assert.AreEqual(0xffd2c2cb, scheme.OnSurfaceVariant);
+            Assert.AreEqual(0xff9a8d95, scheme.Outline);
+            Assert.AreEqual(0xff000000, scheme.Shadow);
+            Assert.AreEqual(0xffeae0e4, scheme.InverseSurface);
+            Assert.AreEqual(0xff342f32, scheme.InverseOnSurface);
+            Assert.AreEqual(0xffab00a2, scheme.InversePrimary);
         }
 
         [TestMethod]
         public void LightContentSchemeFromHighChromaColor()
         {
-            Scheme<int> scheme = new LightSchemeMapper().Map(CorePalette.ContentOf(unchecked((int)0xfffa2bec)));
-            Assert.AreEqual(unchecked((int)0xffab00a2), scheme.Primary);
-            Assert.AreEqual(unchecked((int)0xffffffff), scheme.OnPrimary);
-            Assert.AreEqual(unchecked((int)0xffffd7f3), scheme.PrimaryContainer);
-            Assert.AreEqual(unchecked((int)0xff390035), scheme.OnPrimaryContainer);
-            Assert.AreEqual(unchecked((int)0xff7f4e75), scheme.Secondary);
-            Assert.AreEqual(unchecked((int)0xffffffff), scheme.OnSecondary);
-            Assert.AreEqual(unchecked((int)0xffffd7f3), scheme.SecondaryContainer);
-            Assert.AreEqual(unchecked((int)0xff330b2f), scheme.OnSecondaryContainer);
-            Assert.AreEqual(unchecked((int)0xff9c4323), scheme.Tertiary);
-            Assert.AreEqual(unchecked((int)0xffffffff), scheme.OnTertiary);
-            Assert.AreEqual(unchecked((int)0xffffdbd0), scheme.TertiaryContainer);
-            Assert.AreEqual(unchecked((int)0xff390c00), scheme.OnTertiaryContainer);
-            Assert.AreEqual(unchecked((int)0xffba1a1a), scheme.Error);
-            Assert.AreEqual(unchecked((int)0xffffffff), scheme.OnError);
-            Assert.AreEqual(unchecked((int)0xffffdad6), scheme.ErrorContainer);
-            Assert.AreEqual(unchecked((int)0xff410002), scheme.OnErrorContainer);
-            Assert.AreEqual(unchecked((int)0xfffffbff), scheme.Background);
-            Assert.AreEqual(unchecked((int)0xff1f1a1d), scheme.OnBackground);
-            Assert.AreEqual(unchecked((int)0xfffffbff), scheme.Surface);
-            Assert.AreEqual(unchecked((int)0xff1f1a1d), scheme.OnSurface);
-            Assert.AreEqual(unchecked((int)0xffeedee7), scheme.SurfaceVariant);
-            Assert.AreEqual(unchecked((int)0xff4e444b), scheme.OnSurfaceVariant);
-            Assert.AreEqual(unchecked((int)0xff80747b), scheme.Outline);
-            Assert.AreEqual(unchecked((int)0xff000000), scheme.Shadow);
-            Assert.AreEqual(unchecked((int)0xff342f32), scheme.InverseSurface);
-            Assert.AreEqual(unchecked((int)0xfff8eef2), scheme.InverseOnSurface);
-            Assert.AreEqual(unchecked((int)0xffffabee), scheme.InversePrimary);
+            Scheme<uint> scheme = new LightSchemeMapper().Map(CorePalette.ContentOf(0xfffa2bec));
+            Assert.AreEqual(0xffab00a2, scheme.Primary);
+            Assert.AreEqual(0xffffffff, scheme.OnPrimary);
+            Assert.AreEqual(0xffffd7f3, scheme.PrimaryContainer);
+            Assert.AreEqual(0xff390035, scheme.OnPrimaryContainer);
+            Assert.AreEqual(0xff7f4e75, scheme.Secondary);
+            Assert.AreEqual(0xffffffff, scheme.OnSecondary);
+            Assert.AreEqual(0xffffd7f3, scheme.SecondaryContainer);
+            Assert.AreEqual(0xff330b2f, scheme.OnSecondaryContainer);
+            Assert.AreEqual(0xff9c4323, scheme.Tertiary);
+            Assert.AreEqual(0xffffffff, scheme.OnTertiary);
+            Assert.AreEqual(0xffffdbd0, scheme.TertiaryContainer);
+            Assert.AreEqual(0xff390c00, scheme.OnTertiaryContainer);
+            Assert.AreEqual(0xffba1a1a, scheme.Error);
+            Assert.AreEqual(0xffffffff, scheme.OnError);
+            Assert.AreEqual(0xffffdad6, scheme.ErrorContainer);
+            Assert.AreEqual(0xff410002, scheme.OnErrorContainer);
+            Assert.AreEqual(0xfffffbff, scheme.Background);
+            Assert.AreEqual(0xff1f1a1d, scheme.OnBackground);
+            Assert.AreEqual(0xfffffbff, scheme.Surface);
+            Assert.AreEqual(0xff1f1a1d, scheme.OnSurface);
+            Assert.AreEqual(0xffeedee7, scheme.SurfaceVariant);
+            Assert.AreEqual(0xff4e444b, scheme.OnSurfaceVariant);
+            Assert.AreEqual(0xff80747b, scheme.Outline);
+            Assert.AreEqual(0xff000000, scheme.Shadow);
+            Assert.AreEqual(0xff342f32, scheme.InverseSurface);
+            Assert.AreEqual(0xfff8eef2, scheme.InverseOnSurface);
+            Assert.AreEqual(0xffffabee, scheme.InversePrimary);
         }
 
         [TestMethod]
         public void DarkContentSchemeFromHighChromaColor()
         {
-            Scheme<int> scheme = new DarkSchemeMapper().Map(CorePalette.ContentOf(unchecked((int)0xfffa2bec)));
-            Assert.AreEqual(unchecked((int)0xffffabee), scheme.Primary);
-            Assert.AreEqual(unchecked((int)0xff5c0057), scheme.OnPrimary);
-            Assert.AreEqual(unchecked((int)0xff83007b), scheme.PrimaryContainer);
-            Assert.AreEqual(unchecked((int)0xffffd7f3), scheme.OnPrimaryContainer);
-            Assert.AreEqual(unchecked((int)0xfff0b4e1), scheme.Secondary);
-            Assert.AreEqual(unchecked((int)0xff4b2145), scheme.OnSecondary);
-            Assert.AreEqual(unchecked((int)0xff64375c), scheme.SecondaryContainer);
-            Assert.AreEqual(unchecked((int)0xffffd7f3), scheme.OnSecondaryContainer);
-            Assert.AreEqual(unchecked((int)0xffffb59c), scheme.Tertiary);
-            Assert.AreEqual(unchecked((int)0xff5c1900), scheme.OnTertiary);
-            Assert.AreEqual(unchecked((int)0xff7d2c0d), scheme.TertiaryContainer);
-            Assert.AreEqual(unchecked((int)0xffffdbd0), scheme.OnTertiaryContainer);
-            Assert.AreEqual(unchecked((int)0xffffb4ab), scheme.Error);
-            Assert.AreEqual(unchecked((int)0xff690005), scheme.OnError);
-            Assert.AreEqual(unchecked((int)0xff93000a), scheme.ErrorContainer);
-            Assert.AreEqual(unchecked((int)0xffffb4ab), scheme.OnErrorContainer);
-            Assert.AreEqual(unchecked((int)0xff1f1a1d), scheme.Background);
-            Assert.AreEqual(unchecked((int)0xffeae0e4), scheme.OnBackground);
-            Assert.AreEqual(unchecked((int)0xff1f1a1d), scheme.Surface);
-            Assert.AreEqual(unchecked((int)0xffeae0e4), scheme.OnSurface);
-            Assert.AreEqual(unchecked((int)0xff4e444b), scheme.SurfaceVariant);
-            Assert.AreEqual(unchecked((int)0xffd2c2cb), scheme.OnSurfaceVariant);
-            Assert.AreEqual(unchecked((int)0xff9a8d95), scheme.Outline);
-            Assert.AreEqual(unchecked((int)0xff000000), scheme.Shadow);
-            Assert.AreEqual(unchecked((int)0xffeae0e4), scheme.InverseSurface);
-            Assert.AreEqual(unchecked((int)0xff342f32), scheme.InverseOnSurface);
-            Assert.AreEqual(unchecked((int)0xffab00a2), scheme.InversePrimary);
+            Scheme<uint> scheme = new DarkSchemeMapper().Map(CorePalette.ContentOf(0xfffa2bec));
+            Assert.AreEqual(0xffffabee, scheme.Primary);
+            Assert.AreEqual(0xff5c0057, scheme.OnPrimary);
+            Assert.AreEqual(0xff83007b, scheme.PrimaryContainer);
+            Assert.AreEqual(0xffffd7f3, scheme.OnPrimaryContainer);
+            Assert.AreEqual(0xfff0b4e1, scheme.Secondary);
+            Assert.AreEqual(0xff4b2145, scheme.OnSecondary);
+            Assert.AreEqual(0xff64375c, scheme.SecondaryContainer);
+            Assert.AreEqual(0xffffd7f3, scheme.OnSecondaryContainer);
+            Assert.AreEqual(0xffffb59c, scheme.Tertiary);
+            Assert.AreEqual(0xff5c1900, scheme.OnTertiary);
+            Assert.AreEqual(0xff7d2c0d, scheme.TertiaryContainer);
+            Assert.AreEqual(0xffffdbd0, scheme.OnTertiaryContainer);
+            Assert.AreEqual(0xffffb4ab, scheme.Error);
+            Assert.AreEqual(0xff690005, scheme.OnError);
+            Assert.AreEqual(0xff93000a, scheme.ErrorContainer);
+            Assert.AreEqual(0xffffb4ab, scheme.OnErrorContainer);
+            Assert.AreEqual(0xff1f1a1d, scheme.Background);
+            Assert.AreEqual(0xffeae0e4, scheme.OnBackground);
+            Assert.AreEqual(0xff1f1a1d, scheme.Surface);
+            Assert.AreEqual(0xffeae0e4, scheme.OnSurface);
+            Assert.AreEqual(0xff4e444b, scheme.SurfaceVariant);
+            Assert.AreEqual(0xffd2c2cb, scheme.OnSurfaceVariant);
+            Assert.AreEqual(0xff9a8d95, scheme.Outline);
+            Assert.AreEqual(0xff000000, scheme.Shadow);
+            Assert.AreEqual(0xffeae0e4, scheme.InverseSurface);
+            Assert.AreEqual(0xff342f32, scheme.InverseOnSurface);
+            Assert.AreEqual(0xffab00a2, scheme.InversePrimary);
         }
     }
 }

--- a/MaterialColorUtilities.Tests/ScorerTests.cs
+++ b/MaterialColorUtilities.Tests/ScorerTests.cs
@@ -25,43 +25,43 @@ namespace MaterialColorUtilities.Tests
         [TestMethod]
         public void PrioritizesChromaWhenProportionsAreEqual()
         {
-            Dictionary<int, int> colorsToPopulation = new()
+            Dictionary<uint, uint> colorsToPopulation = new()
             {
-                { unchecked((int)0xffff0000), 1 },
-                { unchecked((int)0xff00ff00), 1 },
-                { unchecked((int)0xff0000ff), 1 },
+                { 0xffff0000, 1 },
+                { 0xff00ff00, 1 },
+                { 0xff0000ff, 1 },
             };
-            List<int> ranked = Scorer.Score(colorsToPopulation);
+            List<uint> ranked = Scorer.Score(colorsToPopulation);
 
-            Assert.AreEqual(unchecked((int)0xffff0000), ranked[0]);
-            Assert.AreEqual(unchecked((int)0xff00ff00), ranked[1]);
-            Assert.AreEqual(unchecked((int)0xff0000ff), ranked[2]);
+            Assert.AreEqual(0xffff0000, ranked[0]);
+            Assert.AreEqual(0xff00ff00, ranked[1]);
+            Assert.AreEqual(0xff0000ff, ranked[2]);
         }
 
         [TestMethod]
         public void GeneratesGBlueWhenNoColorsAvailable()
         {
-            Dictionary<int, int> colorsToPopulation = new()
+            Dictionary<uint, uint> colorsToPopulation = new()
             {
-                { unchecked((int)0xff000000), 1 },
+                { 0xff000000, 1 },
             };
-            List<int> ranked = Scorer.Score(colorsToPopulation);
+            List<uint> ranked = Scorer.Score(colorsToPopulation);
 
-            Assert.AreEqual(unchecked((int)0xff4285F4), ranked[0]);
+            Assert.AreEqual(0xff4285F4, ranked[0]);
         }
 
         [TestMethod]
         public void DedupesNearbyHues()
         {
-            Dictionary<int, int> colorsToPopulation = new()
+            Dictionary<uint, uint> colorsToPopulation = new()
             {
-                { unchecked((int)0xff008772), 1 }, // H 180 C 42 T 50
-                { unchecked((int)0xff318477), 1 }, // H 184 C 35 T 50
+                { 0xff008772, 1 }, // H 180 C 42 T 50
+                { 0xff318477, 1 }, // H 184 C 35 T 50
             };
-            List<int> ranked = Scorer.Score(colorsToPopulation);
+            List<uint> ranked = Scorer.Score(colorsToPopulation);
 
             Assert.AreEqual(1, ranked.Count);
-            Assert.AreEqual(unchecked((int)0xff008772), ranked[0]);
+            Assert.AreEqual(0xff008772, ranked[0]);
         }
 
         // Not yet...

--- a/MaterialColorUtilities.Tests/Utils/Resources.cs
+++ b/MaterialColorUtilities.Tests/Utils/Resources.cs
@@ -1,4 +1,5 @@
-﻿using SkiaSharp;
+﻿using System;
+using SkiaSharp;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -7,12 +8,12 @@ namespace MaterialColorUtilities.Tests.Utils
 {
     public class Resources
     {
-        public static int[] LoadImage(string nameAndExtension)
+        public static uint[] LoadImage(string nameAndExtension)
         {
             string resourceId = $"MaterialColorUtilities.Tests.Resources.{nameAndExtension}";
             using Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceId)!;
             SKBitmap bitmap = SKBitmap.Decode(stream).Resize(new SKImageInfo(112, 112), SKFilterQuality.Low);
-            return bitmap.Pixels.Select(p => (int)(uint)p).ToArray();
+            return Array.ConvertAll(bitmap.Pixels, p => (uint)p);
         }
     }
 }

--- a/MaterialColorUtilities/Blend/Blender.cs
+++ b/MaterialColorUtilities/Blend/Blender.cs
@@ -33,7 +33,7 @@ public static class Blender
     /// The design color with a hue shifted towards the system's color, a slightly
     /// warmer/cooler variant of the design color's hue.
     /// </returns>
-    public static int Harmonize(int designColor, int sourceColor)
+    public static uint Harmonize(uint designColor, uint sourceColor)
     {
         Hct fromHct = Hct.FromInt(designColor);
         Hct toHct = Hct.FromInt(sourceColor);
@@ -54,9 +54,9 @@ public static class Blender
     /// <param name="to">ARGB representation of color</param>
     /// <param name="amount">How much blending to perform; Between 0.0 and 1.0</param>
     /// <returns><paramref name="from"/>, with a hue blended towards <paramref name="to"/>. Chroma and tone are constant.</returns>
-    public static int HctHue(int from, int to, double amount)
+    public static uint HctHue(uint from, uint to, double amount)
     {
-        int ucs = Cam16Ucs(from, to, amount);
+        uint ucs = Cam16Ucs(from, to, amount);
         Cam16 ucsCam = Cam16.FromInt(ucs);
         Cam16 fromCam = Cam16.FromInt(from);
         return Hct.From(ucsCam.Hue, fromCam.Chroma, ColorUtils.LStarFromArgb(from)).ToInt();
@@ -69,7 +69,7 @@ public static class Blender
     /// <param name="to">ARGB representation of color</param>
     /// <param name="amount">How much blending to perform; between 0.0 and 1.0</param>
     /// <returns><paramref name="from"/>, blended towards <paramref name="to"/>. Hue, chroma, and tone will change.</returns>
-    public static int Cam16Ucs(int from, int to, double amount)
+    public static uint Cam16Ucs(uint from, uint to, double amount)
     {
         Cam16 fromCam = Cam16.FromInt(from);
         Cam16 toCam = Cam16.FromInt(to);

--- a/MaterialColorUtilities/ColorAppearance/Cam16.cs
+++ b/MaterialColorUtilities/ColorAppearance/Cam16.cs
@@ -142,19 +142,19 @@ public class Cam16
     /// Create a CAM16 color from a color, assuming the color was viewed in default viewing conditions.
     /// </summary>
     /// <param name="argb">ARGB representation of a color.</param>
-    public static Cam16 FromInt(int argb) => FromIntInViewingConditions(argb, ViewingConditions.Default);
+    public static Cam16 FromInt(uint argb) => FromIntInViewingConditions(argb, ViewingConditions.Default);
 
     /// <summary>
     /// Create a CAM16 color from a color in defined viewing conditions.
     /// </summary>
     /// <param name="argb">ARGB representation of a color.</param>
     /// <param name="viewingConditions">Information about the environment where the color was observed.</param>
-    public static Cam16 FromIntInViewingConditions(int argb, ViewingConditions viewingConditions)
+    public static Cam16 FromIntInViewingConditions(uint argb, ViewingConditions viewingConditions)
     {
         // Transform ARGB int to XYZ
-        int red = (argb & 0x00ff0000) >> 16;
-        int green = (argb & 0x0000ff00) >> 8;
-        int blue = (argb & 0x000000ff);
+        uint red = (argb & 0x00ff0000) >> 16;
+        uint green = (argb & 0x0000ff00) >> 8;
+        uint blue = (argb & 0x000000ff);
         double redL = ColorUtils.Linearized(red);
         double greenL = ColorUtils.Linearized(green);
         double blueL = ColorUtils.Linearized(blue);
@@ -303,14 +303,14 @@ public class Cam16
     /// which are near-identical to the default viewing conditions for sRGB.
     /// </summary>
     /// <returns></returns>
-    public int ToInt() => Viewed(ViewingConditions.Default);
+    public uint ToInt() => Viewed(ViewingConditions.Default);
 
     /// <summary>
     /// ARGB representation of the color, in defined viewing conditions.
     /// </summary>
     /// <param name="viewingConditions">Information about the environment where the color will be viewed.</param>
     /// <returns>ARGB representation of color</returns>
-    public int Viewed(ViewingConditions viewingConditions)
+    public uint Viewed(ViewingConditions viewingConditions)
     {
         double alpha =
             (Chroma == 0.0 || J == 0.0)

--- a/MaterialColorUtilities/ColorAppearance/CamSolver.cs
+++ b/MaterialColorUtilities/ColorAppearance/CamSolver.cs
@@ -549,7 +549,7 @@ public static class CamSolver
     /// <param name="chroma">The desired chroma.</param>
     /// <param name="y">The desired Y.</param>
     /// <returns>The desired color as a hexadecimal integer, if found; 0 otherwise.</returns>
-    static int FindResultByJ(double hueRadians, double chroma, double y)
+    static uint FindResultByJ(double hueRadians, double chroma, double y)
     {
         // Initial estimate of j.
         double j = Math.Sqrt(y) * 11.0;
@@ -625,7 +625,7 @@ public static class CamSolver
     /// chroma, and L* to the desired values, if possible; otherwise, the hue and L* will be
     /// sufficiently close, and chroma will be maximized.
     /// </returns>
-    public static int SolveToInt(double hueDegrees, double chroma, double lstar)
+    public static uint SolveToInt(double hueDegrees, double chroma, double lstar)
     {
         if (chroma < 0.0001 || lstar < 0.0001 || lstar > 99.9999)
         {
@@ -634,7 +634,7 @@ public static class CamSolver
         hueDegrees = MathUtils.SanitizeDegreesDouble(hueDegrees);
         double hueRadians = MathUtils.ToRadians(hueDegrees);
         double y = ColorUtils.YFromLstar(lstar);
-        int exactAnswer = FindResultByJ(hueRadians, chroma, y);
+        uint exactAnswer = FindResultByJ(hueRadians, chroma, y);
         if (exactAnswer != 0)
         {
             return exactAnswer;

--- a/MaterialColorUtilities/ColorAppearance/Hct.cs
+++ b/MaterialColorUtilities/ColorAppearance/Hct.cs
@@ -27,7 +27,7 @@ public class Hct
     private double hue;
     private double chroma;
     private double tone;
-    private int argb;
+    private uint argb;
 
     /// <summary>
     /// Create an HCT color from hue, chroma, and tone.
@@ -41,7 +41,7 @@ public class Hct
     /// <returns>HCT representation of a color in default viewing conditions.</returns>
     public static Hct From(double hue, double chroma, double tone)
     {
-        int argb = CamSolver.SolveToInt(hue, chroma, tone);
+        uint argb = CamSolver.SolveToInt(hue, chroma, tone);
         return new(argb);
     }
 
@@ -50,9 +50,9 @@ public class Hct
     /// </summary>
     /// <param name="argb">ARGB representation of a color</param>
     /// <returns>HCT representation of a color in default viewing conditions</returns>
-    public static Hct FromInt(int argb) => new(argb);
+    public static Hct FromInt(uint argb) => new(argb);
 
-    private Hct(int argb)
+    private Hct(uint argb)
     {
         SetInternalState(argb);
     }
@@ -105,9 +105,9 @@ public class Hct
         set => SetInternalState(CamSolver.SolveToInt(hue, chroma, value));
     }
 
-    public int ToInt() => argb;
+    public uint ToInt() => argb;
 
-    private void SetInternalState(int argb)
+    private void SetInternalState(uint argb)
     {
         this.argb = argb;
         Cam16 cam = Cam16.FromInt(argb);

--- a/MaterialColorUtilities/Palettes/CorePalette.cs
+++ b/MaterialColorUtilities/Palettes/CorePalette.cs
@@ -33,16 +33,16 @@ public class CorePalette
 
     /// <summary>Create key tones from a color.</summary>
     /// <param name="argb">ARGB representation of a color.</param>
-    public static CorePalette Of(int argb) => new(argb);
+    public static CorePalette Of(uint argb) => new(argb);
 
     /// <summary>Create content key tones from a color.</summary>
     /// <param name="argb">ARGB representation of a color.</param>
-    public static CorePalette ContentOf(int argb) => new(argb, true);
+    public static CorePalette ContentOf(uint argb) => new(argb, true);
 
     /// <summary>Create key tones from a color.</summary>
     /// <param name="argb">ARGB representation of a color.</param>
     /// <param name="isContent"></param>
-    public CorePalette(int argb, bool isContent = false)
+    public CorePalette(uint argb, bool isContent = false)
     {
         Hct hct = Hct.FromInt(argb);
         double hue = hct.Hue;

--- a/MaterialColorUtilities/Palettes/TonalPalette.cs
+++ b/MaterialColorUtilities/Palettes/TonalPalette.cs
@@ -23,14 +23,14 @@ namespace MaterialColorUtilities.Palettes;
 /// </summary>
 public class TonalPalette
 {
-    private readonly Dictionary<int, int> cache = new();
+    private readonly Dictionary<uint, uint> cache = new();
     private readonly double hue;
     private readonly double chroma;
 
     /// <summary>Creates tones using the HCT hue and chroma from a color.</summary>
     /// <param name="argb">ARGB representation of a color.</param>
     /// <returns>Tones matching that color's hue and chroma.</returns>
-    public static TonalPalette FromInt(int argb)
+    public static TonalPalette FromInt(uint argb)
     {
         Hct hct = Hct.FromInt(argb);
         return FromHueAndChroma(hct.Hue, hct.Chroma);
@@ -51,13 +51,13 @@ public class TonalPalette
     /// <summary>Creates an ARGB color with HCT hue and chroma of this TonalPalette instance, and the provided HCT tone.</summary>
     /// <param name="tone">HCT tone, measured from 0 to 100.</param>
     /// <returns>ARGB representation of a color with that tone.</returns>
-    public int Tone(int tone)
-        => cache.TryGetValue(tone, out int value)
+    public uint Tone(uint tone)
+        => cache.TryGetValue(tone, out uint value)
             ? value
             : cache[tone] = Hct.From(hue, chroma, tone).ToInt();
 
     /// <summary>Creates an ARGB color with HCT hue and chroma of this TonalPalette instance, and the provided HCT tone.</summary>
     /// <param name="tone">HCT tone, measured from 0 to 100.</param>
     /// <returns>ARGB representation of a color with that tone.</returns>
-    public int this[int tone] => Tone(tone);
+    public uint this[uint tone] => Tone(tone);
 }

--- a/MaterialColorUtilities/Quantize/IPointProvider.cs
+++ b/MaterialColorUtilities/Quantize/IPointProvider.cs
@@ -20,7 +20,7 @@ namespace MaterialColorUtilities.Quantize;
 /// </summary>
 public interface IPointProvider
 {
-    public double[] FromInt(int argb);
-    public int ToInt(double[] point);
+    public double[] FromInt(uint argb);
+    public uint ToInt(double[] point);
     public double Distance(double[] a, double[] b);
 }

--- a/MaterialColorUtilities/Quantize/IQuantizer.cs
+++ b/MaterialColorUtilities/Quantize/IQuantizer.cs
@@ -17,5 +17,5 @@ namespace MaterialColorUtilities.Quantize;
 
 public interface IQuantizer
 {
-    public QuantizerResult Quantize(int[] pixels, int maxColors);
+    public QuantizerResult Quantize(uint[] pixels, uint maxColors);
 }

--- a/MaterialColorUtilities/Quantize/PointProviderLab.cs
+++ b/MaterialColorUtilities/Quantize/PointProviderLab.cs
@@ -26,7 +26,7 @@ public class PointProviderLab : IPointProvider
     /// <summary>
     /// Convert a color represented in ARGB to a 3-element array of L*a*b* coordinates of the color.
     /// </summary>
-    public double[] FromInt(int argb)
+    public double[] FromInt(uint argb)
     {
         double[] lab = ColorUtils.LabFromArgb(argb);
         return new double[] { lab[0], lab[1], lab[2] };
@@ -35,7 +35,7 @@ public class PointProviderLab : IPointProvider
     /// <summary>
     /// Convert a 3-element array to a color represented in ARGB.
     /// </summary>
-    public int ToInt(double[] lab)
+    public uint ToInt(double[] lab)
     {
         return ColorUtils.ArgbFromLab(lab[0], lab[1], lab[2]);
     }

--- a/MaterialColorUtilities/Quantize/QuantizerCelebi.cs
+++ b/MaterialColorUtilities/Quantize/QuantizerCelebi.cs
@@ -40,14 +40,14 @@ public static class QuantizerCelebi
     /// A dictionary with keys of colors in ARGB format, and values of number of pixels in the
     /// original image that correspond to the color in the quantized image.
     /// </returns>
-    public static Dictionary<int, int> Quantize(int[] pixels, int maxColors)
+    public static Dictionary<uint, uint> Quantize(uint[] pixels, uint maxColors)
     {
         QuantizerResult wuResult = new QuantizerWu().Quantize(pixels, maxColors);
 
-        ICollection<int> wuClustersAsObjects = wuResult.ColorToCount.Keys;
-        int index = 0;
-        int[] wuClusters = new int[wuClustersAsObjects.Count];
-        foreach (int argb in wuClustersAsObjects)
+        ICollection<uint> wuClustersAsObjects = wuResult.ColorToCount.Keys;
+        uint index = 0;
+        uint[] wuClusters = new uint[wuClustersAsObjects.Count];
+        foreach (uint argb in wuClustersAsObjects)
         {
             wuClusters[index++] = argb;
         }

--- a/MaterialColorUtilities/Quantize/QuantizerMap.cs
+++ b/MaterialColorUtilities/Quantize/QuantizerMap.cs
@@ -22,13 +22,13 @@ namespace MaterialColorUtilities.Quantize;
 /// </summary>
 public class QuantizerMap : IQuantizer
 {
-    public Dictionary<int, int> ColorToCount { get; } = new();
+    public Dictionary<uint, uint> ColorToCount { get; } = new();
 
-    public QuantizerResult Quantize(int[] pixels, int colorCount)
+    public QuantizerResult Quantize(uint[] pixels, uint colorCount)
     {
-        foreach (int pixel in pixels)
+        foreach (uint pixel in pixels)
         {
-            int alpha = ColorUtils.AlphaFromArgb(pixel);
+            uint alpha = ColorUtils.AlphaFromArgb(pixel);
             if (alpha < 255)
                 continue;
             if (ColorToCount.ContainsKey(pixel))

--- a/MaterialColorUtilities/Quantize/QuantizerResult.cs
+++ b/MaterialColorUtilities/Quantize/QuantizerResult.cs
@@ -20,9 +20,9 @@ namespace MaterialColorUtilities.Quantize;
 /// </summary>
 public class QuantizerResult
 {
-    public Dictionary<int, int> ColorToCount { get; }
+    public Dictionary<uint, uint> ColorToCount { get; }
 
-    public QuantizerResult(Dictionary<int, int> colorToCount)
+    public QuantizerResult(Dictionary<uint, uint> colorToCount)
     {
         ColorToCount = colorToCount;
     }

--- a/MaterialColorUtilities/Quantize/QuantizerWu.cs
+++ b/MaterialColorUtilities/Quantize/QuantizerWu.cs
@@ -41,25 +41,25 @@ public class QuantizerWu : IQuantizer
     private const int INDEX_COUNT = 33; // ((1 << INDEX_BITS) + 1)
     private const int TOTAL_SIZE = 35937; // INDEX_COUNT * INDEX_COUNT * INDEX_COUNT
 
-    public QuantizerResult Quantize(int[] pixels, int colorCount)
+    public QuantizerResult Quantize(uint[] pixels, uint colorCount)
     {
         QuantizerResult mapResult = new QuantizerMap().Quantize(pixels, colorCount);
         ConstructHistogram(mapResult.ColorToCount);
         CreateMoments();
-        CreateBoxesResult createBoxesResult = CreateBoxes(colorCount);
-        List<int> colors = CreateResult(createBoxesResult.ResultCount);
-        Dictionary<int, int> resultMap = new();
-        foreach (int color in colors)
+        CreateBoxesResult createBoxesResult = CreateBoxes((int)colorCount);
+        List<uint> colors = CreateResult(createBoxesResult.ResultCount);
+        Dictionary<uint, uint> resultMap = new();
+        foreach (uint color in colors)
         {
             resultMap[color] = 0;
         }
-        return new QuantizerResult(resultMap);
+        return new(resultMap);
     }
 
     static int GetIndex(int r, int g, int b)
         => (r << (INDEX_BITS * 2)) + (r << (INDEX_BITS + 1)) + r + (g << INDEX_BITS) + g + b;
 
-    void ConstructHistogram(Dictionary<int, int> pixels)
+    void ConstructHistogram(Dictionary<uint, uint> pixels)
     {
         weights = new int[TOTAL_SIZE];
         momentsR = new int[TOTAL_SIZE];
@@ -69,11 +69,11 @@ public class QuantizerWu : IQuantizer
 
         foreach (var pair in pixels)
         {
-            int pixel = pair.Key;
-            int count = pair.Value;
-            int red = ColorUtils.RedFromArgb(pixel);
-            int green = ColorUtils.GreenFromArgb(pixel);
-            int blue = ColorUtils.BlueFromArgb(pixel);
+            uint pixel = pair.Key;
+            int count = (int)pair.Value;
+            int red = (int)ColorUtils.RedFromArgb(pixel);
+            int green = (int)ColorUtils.GreenFromArgb(pixel);
+            int blue = (int)ColorUtils.BlueFromArgb(pixel);
             int bitsToRemove = 8 - INDEX_BITS;
             int iR = (red >> bitsToRemove) + 1;
             int iG = (green >> bitsToRemove) + 1;
@@ -179,9 +179,9 @@ public class QuantizerWu : IQuantizer
         return new CreateBoxesResult(maxColorCount, generatedColorCount);
     }
 
-    List<int> CreateResult(int colorCount)
+    List<uint> CreateResult(int colorCount)
     {
-        List<int> colors = new();
+        List<uint> colors = new();
         for (int i = 0; i < colorCount; ++i)
         {
             Box cube = cubes[i];
@@ -192,7 +192,7 @@ public class QuantizerWu : IQuantizer
                 int g = Volume(cube, momentsG) / weight;
                 int b = Volume(cube, momentsB) / weight;
                 int color = (255 << 24) | ((r & 0x0ff) << 16) | ((g & 0x0ff) << 8) | (b & 0x0ff);
-                colors.Add(color);
+                colors.Add((uint)color);
             }
         }
         return colors;

--- a/MaterialColorUtilities/Schemes/BaseSchemeMapper.cs
+++ b/MaterialColorUtilities/Schemes/BaseSchemeMapper.cs
@@ -7,7 +7,7 @@ namespace MaterialColorUtilities.Schemes
     /// </summary>
     public abstract class BaseSchemeMapper<TCorePalette, TScheme> : ISchemeMapper<TCorePalette, TScheme>
         where TCorePalette : CorePalette
-        where TScheme : Scheme<int>, new()
+        where TScheme : Scheme<uint>, new()
     {
         public TScheme Map(TCorePalette corePalette) => Map(corePalette, new());
 

--- a/MaterialColorUtilities/Schemes/DarkSchemeMapper.cs
+++ b/MaterialColorUtilities/Schemes/DarkSchemeMapper.cs
@@ -4,7 +4,7 @@ using MaterialColorUtilities.Utils;
 namespace MaterialColorUtilities.Schemes
 {
     /// <inheritdoc/>
-    public class DarkSchemeMapper : DarkSchemeMapper<CorePalette, Scheme<int>>
+    public class DarkSchemeMapper : DarkSchemeMapper<CorePalette, Scheme<uint>>
     {
     }
 
@@ -14,7 +14,7 @@ namespace MaterialColorUtilities.Schemes
     /// </summary>
     public class DarkSchemeMapper<TCorePalette, TScheme> : BaseSchemeMapper<TCorePalette, TScheme>
         where TCorePalette : CorePalette
-        where TScheme : Scheme<int>, new()
+        where TScheme : Scheme<uint>, new()
     {
         protected override void MapCore(TCorePalette corePalette, TScheme scheme)
         {

--- a/MaterialColorUtilities/Schemes/IMapper.cs
+++ b/MaterialColorUtilities/Schemes/IMapper.cs
@@ -9,7 +9,7 @@ namespace MaterialColorUtilities.Schemes
     /// <typeparam name="TScheme">The type of the Scheme.</typeparam>
     public interface ISchemeMapper<TCorePalette, TScheme>
         where TCorePalette : CorePalette
-        where TScheme : Scheme<int>, new()
+        where TScheme : Scheme<uint>, new()
     {
         /// <summary>
         /// Maps from a <typeparamref name="TCorePalette"/> to a <typeparamref name="TScheme"/>.

--- a/MaterialColorUtilities/Schemes/LightSchemeMapper.cs
+++ b/MaterialColorUtilities/Schemes/LightSchemeMapper.cs
@@ -4,7 +4,7 @@ using MaterialColorUtilities.Utils;
 namespace MaterialColorUtilities.Schemes
 {
     /// <inheritdoc/>
-    public class LightSchemeMapper : LightSchemeMapper<CorePalette, Scheme<int>>
+    public class LightSchemeMapper : LightSchemeMapper<CorePalette, Scheme<uint>>
     {
     }
 
@@ -14,7 +14,7 @@ namespace MaterialColorUtilities.Schemes
     /// </summary>
     public class LightSchemeMapper<TCorePalette, TScheme> : BaseSchemeMapper<TCorePalette, TScheme>
         where TCorePalette : CorePalette
-        where TScheme : Scheme<int>, new()
+        where TScheme : Scheme<uint>, new()
     {
         protected override void MapCore(TCorePalette corePalette, TScheme scheme)
         {

--- a/MaterialColorUtilities/Score/Scorer.cs
+++ b/MaterialColorUtilities/Score/Scorer.cs
@@ -36,7 +36,7 @@ public static class Scorer
     private const double WEIGHT_CHROMA_ABOVE = 0.3;
     private const double WEIGHT_CHROMA_BELOW = 0.1;
 
-    public const int Default = unchecked((int)0xff4285F4); // Google Blue
+    public const uint Default = 0xff4285F4; // Google Blue
 
     /// <summary>
     /// Given a map with keys of colors and values of how often the color appears, rank the colors
@@ -52,7 +52,7 @@ public static class Scorer
     /// all the input colors were not suitable for a theme, a default fallback color will be provided,
     /// Google Blue.
     /// </returns>
-    public static List<int> Score(Dictionary<int, int> colorsToPopulation)
+    public static List<uint> Score(Dictionary<uint, uint> colorsToPopulation)
     {
         // Determine the total count of all colors.
         double populationSum = 0;
@@ -64,34 +64,34 @@ public static class Scorer
         // Turn the count of each color into a proportion by dividing by the total
         // count. Also, fill a cache of CAM16 colors representing each color, and
         // record the proportion of colors for each CAM16 hue.
-        Dictionary<int, Cam16> colorsToCam = new();
+        Dictionary<uint, Cam16> colorsToCam = new();
         double[] hueProportions = new double[361];
         foreach (var entry in colorsToPopulation)
         {
-            int color = entry.Key;
+            uint color = entry.Key;
             double population = entry.Value;
             double proportion = population / populationSum;
 
             Cam16 cam = Cam16.FromInt(color);
             colorsToCam[color] = cam;
 
-            int hue = (int)Math.Round(cam.Hue);
+            uint hue = (uint)Math.Round(cam.Hue);
             hueProportions[hue] += proportion;
         }
 
         // Determine the proportion of the colors around each color, by summing the
         // proportions around each color's hue.
-        Dictionary<int, double> colorsToExcitedProportion = new();
+        Dictionary<uint, double> colorsToExcitedProportion = new();
         foreach (var entry in colorsToCam)
         {
-            int color = entry.Key;
+            uint color = entry.Key;
             Cam16 cam = entry.Value;
             int hue = (int)Math.Round(cam.Hue);
 
             double excitedProportion = 0;
             for (int j = hue - 15; j < (hue + 15); j++)
             {
-                int neighborHue = MathUtils.SanitizeDegreesInt(j);
+                uint neighborHue = MathUtils.SanitizeDegreesInt(j);
                 excitedProportion += hueProportions[neighborHue];
             }
 
@@ -99,10 +99,10 @@ public static class Scorer
         }
 
         // Score the colors by their proportion, as well as how chromatic they are.
-        Dictionary<int, double> colorsToScore = new();
+        Dictionary<uint, double> colorsToScore = new();
         foreach (var entry in colorsToCam)
         {
-            int color = entry.Key;
+            uint color = entry.Key;
             Cam16 cam = entry.Value;
 
             double proportion = colorsToExcitedProportion[color];
@@ -118,25 +118,25 @@ public static class Scorer
 
         // Remove colors that are unsuitable, ex. very dark or unchromatic colors.
         // Also, remove colors that are very similar in hue.
-        List<int> filteredColors = Filter(colorsToExcitedProportion, colorsToCam);
-        Dictionary<int, double> filteredColorsToScore = new();
-        foreach (int color in filteredColors)
+        List<uint> filteredColors = Filter(colorsToExcitedProportion, colorsToCam);
+        Dictionary<uint, double> filteredColorsToScore = new();
+        foreach (uint color in filteredColors)
         {
             filteredColorsToScore[color] = colorsToScore[color];
         }
 
         // Ensure the list of colors returned is sorted such that the first in the
         // list is the most suitable, and the last is the least suitable.
-        List<KeyValuePair<int, double>> entryList = new(filteredColorsToScore);
+        List<KeyValuePair<uint, double>> entryList = new(filteredColorsToScore);
         entryList.Sort((a, b) => b.Value.CompareTo(a.Value));
-        List<int> colorsByScoreDescending = new();
+        List<uint> colorsByScoreDescending = new();
         foreach (var entry in entryList)
         {
-            int color = entry.Key;
+            uint color = entry.Key;
             Cam16 cam = colorsToCam[color];
             bool duplicateHue = false;
 
-            foreach (int alreadyChosenColor in colorsByScoreDescending)
+            foreach (uint alreadyChosenColor in colorsByScoreDescending)
             {
                 Cam16 alreadyChosenCam = colorsToCam[alreadyChosenColor];
                 if (MathUtils.DifferenceDegrees(cam.Hue, alreadyChosenCam.Hue) < 15)
@@ -161,13 +161,13 @@ public static class Scorer
         return colorsByScoreDescending;
     }
 
-    private static List<int> Filter(
-        Dictionary<int, double> colorsToExcitedProportion, Dictionary<int, Cam16> colorsToCam)
+    private static List<uint> Filter(
+        Dictionary<uint, double> colorsToExcitedProportion, Dictionary<uint, Cam16> colorsToCam)
     {
-        List<int> filtered = new();
+        List<uint> filtered = new();
         foreach (var entry in colorsToCam)
         {
-            int color = entry.Key;
+            uint color = entry.Key;
             Cam16 cam = entry.Value;
             double proportion = colorsToExcitedProportion[color];
 

--- a/MaterialColorUtilities/Utils/ColorUtils.cs
+++ b/MaterialColorUtilities/Utils/ColorUtils.cs
@@ -44,71 +44,71 @@ public static class ColorUtils
     public static double[] WhitePointD65 { get; } = { 95.047, 100, 108.883 };
 
     /// <summary>Converts a color from RGB components to ARGB format.</summary>
-    public static int ArgbFromRgb(int red, int green, int blue)
+    public static uint ArgbFromRgb(uint red, uint green, uint blue)
     {
-        return (255 << 24) | ((red & 255) << 16) | ((green & 255) << 8) | (blue & 255);
+        return (255u << 24) | ((red & 255) << 16) | ((green & 255) << 8) | (blue & 255);
     }
 
     /// <summary>Converts a color from ARGB components to ARGB format.</summary>
-    public static int ArgbFromComponents(int alpha, int red, int green, int blue)
+    public static uint ArgbFromComponents(uint alpha, uint red, uint green, uint blue)
     {
         return ((alpha & 255) << 24) | ((red & 255) << 16) | ((green & 255) << 8) | (blue & 255);
     }
 
     /// <summary>Converts a color from linear RGB components to ARGB format.</summary>
-    public static int ArgbFromLinrgb(double[] linrgb)
+    public static uint ArgbFromLinrgb(double[] linrgb)
     {
-        int r = Delinearized(linrgb[0]);
-        int g = Delinearized(linrgb[1]);
-        int b = Delinearized(linrgb[2]);
+        uint r = Delinearized(linrgb[0]);
+        uint g = Delinearized(linrgb[1]);
+        uint b = Delinearized(linrgb[2]);
         return ArgbFromRgb(r, g, b);
     }
 
     /// <summary>Returns the alpha component of a color in ARGB format.</summary>
-    public static int AlphaFromArgb(int argb)
+    public static uint AlphaFromArgb(uint argb)
     {
         return (argb >> 24) & 255;
     }
 
     /// <summary>Returns the red component of a color in ARGB format.</summary>
-    public static int RedFromArgb(int argb)
+    public static uint RedFromArgb(uint argb)
     {
         return (argb >> 16) & 255;
     }
 
     /// <summary>Returns the green component of a color in ARGB format.</summary>
-    public static int GreenFromArgb(int argb)
+    public static uint GreenFromArgb(uint argb)
     {
         return (argb >> 8) & 255;
     }
 
     /// <summary>Returns the blue component of a color in ARGB format.</summary>
-    public static int BlueFromArgb(int argb)
+    public static uint BlueFromArgb(uint argb)
     {
         return argb & 255;
     }
 
     /// <summary>Returns whether a color in ARGB format is opaque.</summary>
-    public static bool IsOpaque(int argb)
+    public static bool IsOpaque(uint argb)
     {
         return AlphaFromArgb(argb) >= 255;
     }
 
     /// <summary>Converts a color from XYZ to ARGB.</summary> 
-    public static int ArgbFromXyz(double x, double y, double z)
+    public static uint ArgbFromXyz(double x, double y, double z)
     {
         double[][] matrix = XyzToSrgb;
         double linearR = matrix[0][0] * x + matrix[0][1] * y + matrix[0][2] * z;
         double linearG = matrix[1][0] * x + matrix[1][1] * y + matrix[1][2] * z;
         double linearB = matrix[2][0] * x + matrix[2][1] * y + matrix[2][2] * z;
-        int r = Delinearized(linearR);
-        int g = Delinearized(linearG);
-        int b = Delinearized(linearB);
+        uint r = Delinearized(linearR);
+        uint g = Delinearized(linearG);
+        uint b = Delinearized(linearB);
         return ArgbFromRgb(r, g, b);
     }
 
     /// <summary>Converts a color from ARGB to XYZ.</summary>
-    public static double[] XyzFromArgb(int argb)
+    public static double[] XyzFromArgb(uint argb)
     {
         double r = Linearized(RedFromArgb(argb));
         double g = Linearized(GreenFromArgb(argb));
@@ -117,7 +117,7 @@ public static class ColorUtils
     }
 
     /// <summary>Converts a color represented in Lab color space into an ARGB integer.</summary>
-    public static int ArgbFromLab(double l, double a, double b)
+    public static uint ArgbFromLab(double l, double a, double b)
     {
         double[] whitePoint = WhitePointD65;
         double fy = (l + 16.0) / 116.0;
@@ -133,7 +133,7 @@ public static class ColorUtils
     }
 
     /// <summary>Converts a color from ARGB representation to L*a*b* representation.</summary>
-    public static double[] LabFromArgb(int argb)
+    public static double[] LabFromArgb(uint argb)
     {
         double linearR = Linearized(RedFromArgb(argb));
         double linearG = Linearized(GreenFromArgb(argb));
@@ -158,7 +158,7 @@ public static class ColorUtils
     /// <summary>Converts an L* value to an ARGB representation.</summary>
     /// <param name="l">L* in L*a*b*</param>
     /// <returns>ARGB representation of grayscale color with lightness matching L*</returns>
-    public static int ArgbFromLstar(double lstar)
+    public static uint ArgbFromLstar(double lstar)
     {
         double fy = (lstar + 16.0) / 116.0;
         double fz = fy;
@@ -177,7 +177,7 @@ public static class ColorUtils
     /// <summary>Computes the L* value of a color in ARGB representation.</summary>
     /// <param name="argb">ARGB representation of a color</param>
     /// <returns>L*, from L*a*b*, coordinate of the color</returns>
-    public static double LStarFromArgb(int argb)
+    public static double LStarFromArgb(uint argb)
     {
         double y = XyzFromArgb(argb)[1] / 100.0;
         double e = 216.0 / 24389.0;
@@ -220,7 +220,7 @@ public static class ColorUtils
     /// </summary>
     /// <param name="rgbComponent">0 ≤ rgb_component ≤ 255, represents R/G/B channel</param>
     /// <returns>0.0 ≤ output ≤ 100.0, color channel converted to linear RGB space</returns>
-    public static double Linearized(int rgbComponent)
+    public static double Linearized(uint rgbComponent)
     {
         double normalized = rgbComponent / 255.0;
         if (normalized <= 0.040449936)
@@ -238,7 +238,7 @@ public static class ColorUtils
     /// </summary>
     /// <param name="rgbComponent">0.0 ≤ rgb_component ≤ 100.0, represents linear R/G/B channel</param>
     /// <returns>0 ≤ output ≤ 255, color channel converted to regular RGB space</returns>
-    public static int Delinearized(double rgbComponent)
+    public static uint Delinearized(double rgbComponent)
     {
         double normalized = rgbComponent / 100.0;
         double delinearized;
@@ -250,13 +250,13 @@ public static class ColorUtils
         {
             delinearized = 1.055 * Math.Pow(normalized, 1.0 / 2.4) - 0.055;
         }
-        return MathUtils.ClampInt(0, 255, (int)Math.Round(delinearized * 255.0));
+        return (uint)MathUtils.ClampInt(0, 255, (int)Math.Round(delinearized * 255.0));
     }
 
     public static double LabF(double t)
     {
-        double e = 216.0 / 24389.0;
-        double kappa = 24389.0 / 27.0;
+        const double e = 216.0 / 24389.0;
+        const double kappa = 24389.0 / 27.0;
         if (t > e)
         {
             return Math.Pow(t, 1.0 / 3.0);
@@ -282,14 +282,14 @@ public static class ColorUtils
         }
     }
 
-    public static int Add(this int background, int foreground, double foregroundAlpha)
+    public static uint Add(this uint background, uint foreground, double foregroundAlpha)
     {
-        int a = (int)(foregroundAlpha * 255);
+        uint a = (uint)(foregroundAlpha * 255);
         foreground &= (a << 24) | 0x00FFFFFF;
         return Add(background, foreground);
     }
 
-    public static int Add(this int background, int foreground)
+    public static uint Add(this uint background, uint foreground)
     {
         DeconstructArgb(background,
             out float bgA,
@@ -309,10 +309,10 @@ public static class ColorUtils
         float b = CompositeComponent(fgB, bgB, fgA, bgA, a);
 
         return ArgbFromComponents(
-            (int)(a * 255),
-            (int)(r * 255),
-            (int)(g * 255),
-            (int)(b * 255));
+            (uint)(a * 255),
+            (uint)(r * 255),
+            (uint)(g * 255),
+            (uint)(b * 255));
     }
 
     public static float CompositeComponent(float fgC, float bgC, float fgA, float bgA, float a)
@@ -322,7 +322,7 @@ public static class ColorUtils
     }
 
     public static void DeconstructArgb(
-        int argb,
+        uint argb,
         out float a,
         out float r,
         out float g,

--- a/MaterialColorUtilities/Utils/ImageUtils.cs
+++ b/MaterialColorUtilities/Utils/ImageUtils.cs
@@ -28,7 +28,7 @@ public static class ImageUtils
     /// The extracted colors in descending order by score.
     /// At least one color will be returned.
     /// </returns>
-    public static List<int> ColorsFromImage(int[] pixels)
+    public static List<uint> ColorsFromImage(uint[] pixels)
     {
         var result = QuantizerCelebi.Quantize(pixels, 128);
         var ranked = Scorer.Score(result);

--- a/MaterialColorUtilities/Utils/MathUtils.cs
+++ b/MaterialColorUtilities/Utils/MathUtils.cs
@@ -59,14 +59,14 @@ public static class MathUtils
 
     /// <summary>Sanitizes a degree measure as an integer.</summary>
     /// <returns>A degree measure between 0 (inclusive) and 360 (exclusive).</returns>
-    public static int SanitizeDegreesInt(int degrees)
+    public static uint SanitizeDegreesInt(int degrees)
     {
         degrees %= 360;
         if (degrees < 0)
         {
             degrees += 360;
         }
-        return degrees;
+        return (uint)degrees;
     }
 
     /// <summary>Sanitizes a degree measure as a floating-point number.</summary>

--- a/MaterialColorUtilities/Utils/StringUtils.cs
+++ b/MaterialColorUtilities/Utils/StringUtils.cs
@@ -9,6 +9,6 @@
         /// Hex string representing color, ex. #ff0000 for red.
         /// </summary>
         /// <param name="argb">ARGB representation of a color.</param>
-        public static string HexFromArgb(int argb) => "#" + argb.ToString("X").Substring(2);
+        public static string HexFromArgb(uint argb) => "#" + argb.ToString("X").Substring(2);
     }
 }

--- a/Playground/Playground.Console/Program.cs
+++ b/Playground/Playground.Console/Program.cs
@@ -13,10 +13,10 @@ using System.Reflection;
 string imageResourceId = "Playground.Console.Resources.wallpaper.webp";
 using Stream resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(imageResourceId);
 SKBitmap bitmap = SKBitmap.Decode(resourceStream).Resize(new SKImageInfo(112, 112), SKFilterQuality.Medium);
-int[] pixels = bitmap.Pixels.Select(p => (int)(uint)p).ToArray();
+uint[] pixels = Array.ConvertAll(bitmap.Pixels, p => (uint)p);
 
 // This is where the magic happens
-int seedColor = ImageUtils.ColorsFromImage(pixels).First();
+uint seedColor = ImageUtils.ColorsFromImage(pixels).First();
 
 Console.WriteLine($"Seed: {StringUtils.HexFromArgb(seedColor)}");
 
@@ -25,11 +25,11 @@ CorePalette corePalette = new(seedColor);
 
 // Map the core palette to color schemes
 // A Scheme contains the named colors, like Primary or OnTertiaryContainer
-Scheme<int> lightScheme = new LightSchemeMapper().Map(corePalette);
-Scheme<int> darkScheme = new DarkSchemeMapper().Map(corePalette);
+Scheme<uint> lightScheme = new LightSchemeMapper().Map(corePalette);
+Scheme<uint> darkScheme = new DarkSchemeMapper().Map(corePalette);
 
 // Easily convert between Schemes with different color types
-Scheme<Color> lightSchemeColor = lightScheme.ConvertTo(Color.FromArgb);
+Scheme<Color> lightSchemeColor = lightScheme.ConvertTo(x => Color.FromArgb((int)x));
 
 Scheme<string> lightSchemeString = lightScheme.ConvertTo(x => "#" + x.ToString("X")[2..]);
 ConsoleHelper.PrintProperties("Light scheme", lightSchemeString);
@@ -53,10 +53,10 @@ public class MyCorePalette : CorePalette
 {
     public TonalPalette Orange { get; set; }
     
-    public MyCorePalette(int seed) : base(seed)
+    public MyCorePalette(uint seed) : base(seed)
     {
         // You can harmonize a color to make it closer to the seed color
-        int harmonizedOrange = Blender.Harmonize(unchecked(0xFFA500), seed);
+        uint harmonizedOrange = Blender.Harmonize(0xFFA500, seed);
         Orange = TonalPalette.FromInt(harmonizedOrange);
     }
 }
@@ -73,9 +73,9 @@ public partial class MyScheme<TColor> : Scheme<TColor>
 }
 
 // 3. Create mappers
-public class MyLightSchemeMapper : LightSchemeMapper<MyCorePalette, MyScheme<int>>
+public class MyLightSchemeMapper : LightSchemeMapper<MyCorePalette, MyScheme<uint>>
 {
-    protected override void MapCore(MyCorePalette palette, MyScheme<int> scheme)
+    protected override void MapCore(MyCorePalette palette, MyScheme<uint> scheme)
     {
         base.MapCore(palette, scheme);
         scheme.Orange = palette.Orange[40];
@@ -88,9 +88,9 @@ public class MyLightSchemeMapper : LightSchemeMapper<MyCorePalette, MyScheme<int
     }
 }
 
-public class MyDarkSchemeMapper : DarkSchemeMapper<MyCorePalette, MyScheme<int>>
+public class MyDarkSchemeMapper : DarkSchemeMapper<MyCorePalette, MyScheme<uint>>
 {
-    protected override void MapCore(MyCorePalette palette, MyScheme<int> scheme)
+    protected override void MapCore(MyCorePalette palette, MyScheme<uint> scheme)
     {
         base.MapCore(palette, scheme);
         scheme.Orange = palette.Orange[80];

--- a/Playground/Playground.Maui/Components/ColorPlot.cs
+++ b/Playground/Playground.Maui/Components/ColorPlot.cs
@@ -2,12 +2,12 @@
 
 public class ColorPlot : GraphicsView
 {
-    private readonly Func<double, double, int> _func;
+    private readonly Func<double, double, uint> _func;
     private readonly double _xMax;
     private readonly double _yMax;
     private readonly Color[,] _pixels = new Color[400, 200];
 
-    public ColorPlot(Func<double, double, int> func, string xLabel, double xMax, string yLabel, double yMax)
+    public ColorPlot(Func<double, double, uint> func, string xLabel, double xMax, string yLabel, double yMax)
     {
         _func = func;
         _xMax = xMax;
@@ -37,9 +37,9 @@ public class ColorPlot : GraphicsView
         //}
         Parallel.For(0, 200, y =>
         {
-            for (var x = 0; x < 400; x++)
+            for (uint x = 0; x < 400; x++)
             {
-                _pixels[x, y] = Color.FromInt(_func(x / 400.0 * _xMax, y / 200.0 * _yMax));
+                _pixels[x, y] = Color.FromUint(_func(x / 400.0 * _xMax, y / 200.0 * _yMax));
             }
         });
     }

--- a/Playground/Playground.Maui/CustomDynamicColorService.cs
+++ b/Playground/Playground.Maui/CustomDynamicColorService.cs
@@ -12,7 +12,7 @@ using Microsoft.Maui.Platform;
 
 namespace Playground.Maui;
 
-public class CustomDynamicColorService : DynamicColorService<CorePalette, AppScheme<int>, AppScheme<Color>, LightAppSchemeMapper, DarkAppSchemeMapper>
+public class CustomDynamicColorService : DynamicColorService<CorePalette, AppScheme<uint>, AppScheme<Color>, LightAppSchemeMapper, DarkAppSchemeMapper>
 {
     private readonly WeakEventManager _weakEventManager = new();
     

--- a/Playground/Playground.Maui/ViewModels/ThemeViewModel.cs
+++ b/Playground/Playground.Maui/ViewModels/ThemeViewModel.cs
@@ -62,13 +62,13 @@ public partial class ThemeViewModel : ObservableObject
     void SetSeed()
     {
         Hct hct = Hct.From(H, C, T);
-        Seed = Color.FromInt(hct.ToInt());
+        Seed = Color.FromUint(hct.ToInt());
         _colorService.Seed = hct.ToInt();
     }
 
     void SetFromSeed()
     {
-        Seed = Color.FromInt(_colorService.Seed);
+        Seed = Color.FromUint(_colorService.Seed);
         Hct hct = Hct.FromInt(_colorService.Seed);
         _h = hct.Hue;
         _c = hct.Chroma;

--- a/Playground/Playground.Maui/Views/GraphsPage.xaml.cs
+++ b/Playground/Playground.Maui/Views/GraphsPage.xaml.cs
@@ -17,13 +17,13 @@ public partial class GraphsPage : ContentPage
             "CAM16 from JCH, chroma = 100",
             "Hue", 360,
             "Lightness", 100);
-        Plot((x, y) => Color.FromHsla(x, 1, y).ToInt(),
+        Plot((x, y) => Color.FromHsla(x, 1, y).ToUint(),
             "HSL, saturation = 1",
             "Hue", 1,
             "Lightness", 1);
     }
 
-    private void Plot(Func<double, double, int> func, string title, string xLabel, double xMax, string yLabel, double yMax)
+    private void Plot(Func<double, double, uint> func, string title, string xLabel, double xMax, string yLabel, double yMax)
     {
         stack.Add(new Label { Text = title });
         stack.Add(new ColorPlot(func, xLabel, xMax, yLabel, yMax) { Margin = new Thickness(0, 0, 0, 32) });

--- a/Playground/Playground.Shared/AppScheme.cs
+++ b/Playground/Playground.Shared/AppScheme.cs
@@ -7,17 +7,17 @@ public partial class AppScheme<TColor> : Scheme<TColor>
 {
 }
 
-public class DarkAppSchemeMapper : DarkSchemeMapper<CorePalette, AppScheme<int>>
+public class DarkAppSchemeMapper : DarkSchemeMapper<CorePalette, AppScheme<uint>>
 {
-    protected override void MapCore(CorePalette corePalette, AppScheme<int> scheme)
+    protected override void MapCore(CorePalette corePalette, AppScheme<uint> scheme)
     {
         base.MapCore(corePalette, scheme);
     }
 }
 
-public class LightAppSchemeMapper : LightSchemeMapper<CorePalette, AppScheme<int>>
+public class LightAppSchemeMapper : LightSchemeMapper<CorePalette, AppScheme<uint>>
 {
-    protected override void MapCore(CorePalette corePalette, AppScheme<int> scheme)
+    protected override void MapCore(CorePalette corePalette, AppScheme<uint> scheme)
     {
         base.MapCore(corePalette, scheme);
     }

--- a/Playground/Playground.Wasm/Extensions/IntExtensions.cs
+++ b/Playground/Playground.Wasm/Extensions/IntExtensions.cs
@@ -5,10 +5,10 @@ namespace Playground.Wasm.Extensions
 {
     public static class IntExtensions
     {
-        public static MudColor ToMudColor(this int argb) => new(
-            ColorUtils.RedFromArgb(argb),
-            ColorUtils.GreenFromArgb(argb),
-            ColorUtils.BlueFromArgb(argb),
-            ColorUtils.AlphaFromArgb(argb));
+        public static MudColor ToMudColor(this uint argb) => new(
+            (int)ColorUtils.RedFromArgb(argb),
+            (int)ColorUtils.GreenFromArgb(argb),
+            (int)ColorUtils.BlueFromArgb(argb),
+            (int)ColorUtils.AlphaFromArgb(argb));
     }
 }

--- a/Playground/Playground.Wasm/Extensions/SKCanvasExtensions.cs
+++ b/Playground/Playground.Wasm/Extensions/SKCanvasExtensions.cs
@@ -40,9 +40,9 @@ public static class SKPaintSurfaceEventArgsExtensions
         double maxY,
         string labelX,
         string labelY,
-        Scheme<int> scheme)
+        Scheme<uint> scheme)
     {
-        stroke.Color = left.Color = center.Color = right.Color = new((uint)scheme.Outline);
+        stroke.Color = left.Color = center.Color = right.Color = new(scheme.Outline);
 
         var canvas = args.Surface.Canvas;
         float width = args.Info.Width;

--- a/Playground/Playground.Wasm/Pages/Graphs.razor
+++ b/Playground/Playground.Wasm/Pages/Graphs.razor
@@ -4,7 +4,7 @@
 <h1>Function graphs</h1>
 
 <h3>Linearized</h3>
-<Plot2D Func="@(x => ColorUtils.Linearized((int)x))" MaxX="255" />
+<Plot2D Func="@(x => ColorUtils.Linearized((uint)x))" MaxX="255" />
 
 <h3>Delinearized</h3>
 <Plot2D Func="@(x => ColorUtils.Delinearized((int)x))" MaxY="255" />

--- a/Playground/Playground.Wasm/Pages/Index.razor
+++ b/Playground/Playground.Wasm/Pages/Index.razor
@@ -101,28 +101,28 @@
 </MudContainer>
 
 @code {
-    private int Hsl(double x, double y)
+    private uint Hsl(double x, double y)
     {
         MudColor mudColor = new(x, 1, y, 1);
         return ColorUtils.ArgbFromRgb(mudColor.R, mudColor.G, mudColor.B);
     }
 
-    private (double, double) HslInverse(int color)
+    private (double, double) HslInverse(uint color)
     {
         MudColor mudColor = new(ColorUtils.RedFromArgb(color), ColorUtils.GreenFromArgb(color), ColorUtils.BlueFromArgb(color), 255);
         return (mudColor.H, mudColor.L);
     }
 
-    private int Okhsl(double x, double y)
+    private uint Okhsl(double x, double y)
     {
         var (r,g,b) = OkColor.OkHslToSrgb((x, 1, y));
         return ColorUtils.ArgbFromRgb(
-            (int)(r * 255),
-            (int)(g * 255),
-            (int)(b * 255));
+            (uint)(r * 255),
+            (uint)(g * 255),
+            (uint)(b * 255));
     }
 
-    private (double, double) OkhslInverse(int color)
+    private (double, double) OkhslInverse(uint color)
     {
         var okhsl = OkColor.SrgbToOkHsl((
             ColorUtils.RedFromArgb(color) / 255.0,

--- a/Playground/Playground.Wasm/Services/ThemeService.cs
+++ b/Playground/Playground.Wasm/Services/ThemeService.cs
@@ -10,7 +10,7 @@ namespace Playground.Wasm.Services;
 
 public class ThemeService
 {
-    private int _seed = Scorer.Default;
+    private uint _seed = Scorer.Default;
     private bool _isDark;
     private readonly LightAppSchemeMapper _lightMapper = new();
     private readonly DarkAppSchemeMapper _darkMapper = new();
@@ -27,8 +27,8 @@ public class ThemeService
             ThemeChanged?.Invoke();
         }
     }
-    public int Seed => _seed;
-    public AppScheme<int> Scheme { get; set; }
+    public uint Seed => _seed;
+    public AppScheme<uint> Scheme { get; set; }
     public MudTheme MudTheme { get; } = new()
     {
         ZIndex = new()
@@ -37,10 +37,10 @@ public class ThemeService
         }
     };
 
-    public event EventHandler<int> SeedChanged;
+    public event EventHandler<uint> SeedChanged;
     public event Action ThemeChanged;
 
-    public void SetSeed(int value, object sender)
+    public void SetSeed(uint value, object sender)
     {
         _seed = value;
         SeedChanged?.Invoke(sender, value);
@@ -50,7 +50,7 @@ public class ThemeService
     private void Apply()
     {
         CorePalette corePalette = new(Seed);
-        ISchemeMapper<CorePalette, AppScheme<int>> mapper = IsDark
+        ISchemeMapper<CorePalette, AppScheme<uint>> mapper = IsDark
             ? _darkMapper
             : _lightMapper;
         Scheme = mapper.Map(corePalette);

--- a/Playground/Playground.Wasm/Shared/ColorInput.razor
+++ b/Playground/Playground.Wasm/Shared/ColorInput.razor
@@ -21,7 +21,7 @@
         {
             if (_color == value) return;
             _color = value;
-            int color = ColorUtils.ArgbFromRgb(
+            uint color = ColorUtils.ArgbFromRgb(
                 value.R,
                 value.G,
                 value.B
@@ -30,7 +30,7 @@
         }
     }
 
-    protected override void SetFromSeed(int seed)
+    protected override void SetFromSeed(uint seed)
     {
         _color = StringUtils.HexFromArgb(seed);
     }

--- a/Playground/Playground.Wasm/Shared/ColorPlot.razor.cs
+++ b/Playground/Playground.Wasm/Shared/ColorPlot.razor.cs
@@ -26,8 +26,8 @@ public partial class ColorPlot : SeedColorSelector
     /// </summary>
     [Parameter] public int Resolution { get; set; } = 400;
 
-    [Parameter] public Func<double, double, int> Func { get; set; }
-    [Parameter] public Func<int, (double, double)> FuncInverse { get; set; }
+    [Parameter] public Func<double, double, uint> Func { get; set; }
+    [Parameter] public Func<uint, (double, double)> FuncInverse { get; set; }
     [Parameter] public double MinX { get; set; } = 0;
     [Parameter] public double MinY { get; set; } = 0;
     [Parameter] public double MaxX { get; set; } = 100;
@@ -42,8 +42,8 @@ public partial class ColorPlot : SeedColorSelector
         {
             for (int y = 0; y < bitmap.Height; y++)
             {
-                int color = GetColor(x, y);
-                bitmap.SetPixel(x, bitmap.Height - 1 - y, (uint)color);
+                uint color = GetColor(x, y);
+                bitmap.SetPixel(x, bitmap.Height - 1 - y, color);
             }
         }
         bitmap = bitmap.Resize(new SKImageInfo(400, 200), SKFilterQuality.None);
@@ -68,12 +68,12 @@ public partial class ColorPlot : SeedColorSelector
             return;
         seedX = args.OffsetX - 20;
         seedY = bitmap.Height - (args.OffsetY - 20);
-        int color = GetColor(seedX, seedY);
+        uint color = GetColor(seedX, seedY);
         themeService.SetSeed(color, this);
         view?.Invalidate();
     }
 
-    protected override void SetFromSeed(int seed)
+    protected override void SetFromSeed(uint seed)
     {
         if (FuncInverse == null) return;
         var xy = FuncInverse(seed);
@@ -84,7 +84,7 @@ public partial class ColorPlot : SeedColorSelector
         view?.Invalidate();
     }
 
-    private int GetColor(double x, double y)
+    private uint GetColor(double x, double y)
         => Func(
             x / bitmap.Width * (MaxX - MinX) + MinX,
             y / bitmap.Height * (MaxY - MinY) + MinY

--- a/Playground/Playground.Wasm/Shared/Colors.razor
+++ b/Playground/Playground.Wasm/Shared/Colors.razor
@@ -44,9 +44,9 @@
 </MudHidden>
 
 @code {
-    protected override void SetFromSeed(int seed) { }
+    protected override void SetFromSeed(uint seed) { }
 
-    string ToStyle(int color)
+    string ToStyle(uint color)
     {
         double tone = ColorUtils.LStarFromArgb(color);
         string textColor = tone > 50

--- a/Playground/Playground.Wasm/Shared/HctSliders.razor.cs
+++ b/Playground/Playground.Wasm/Shared/HctSliders.razor.cs
@@ -15,7 +15,7 @@ namespace Playground.Wasm.Shared
         double Chroma { get => _chroma; set { if (_chroma == value) return; _chroma = value; HctChanged(); } }
         double Tone { get => _tone; set { if (_tone == value) return; _tone = value; HctChanged(); } }
 
-        protected override void SetFromSeed(int seed)
+        protected override void SetFromSeed(uint seed)
         {
             _hct = Hct.FromInt(seed);
             _hue = _hct.Hue;
@@ -27,7 +27,7 @@ namespace Playground.Wasm.Shared
         void HctChanged()
         {
             _hct = Hct.From(Hue, Chroma, Tone);
-            int color = _hct.ToInt();
+            uint color = _hct.ToInt();
             ThemeService.SetSeed(color, this);
             _showActualValues = true;
         }

--- a/Playground/Playground.Wasm/Shared/SeedColorSelector.cs
+++ b/Playground/Playground.Wasm/Shared/SeedColorSelector.cs
@@ -14,14 +14,14 @@ namespace Playground.Wasm.Shared
             OnSeedChanged(null, ThemeService.Seed);
         }
 
-        private void OnSeedChanged(object sender, int e)
+        private void OnSeedChanged(object sender, uint e)
         {
             if (sender == this) return;
             SetFromSeed(e);
             StateHasChanged();
         }
 
-        protected abstract void SetFromSeed(int seed);
+        protected abstract void SetFromSeed(uint seed);
 
         public void Dispose()
         {

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You can specify the fallback seed as an argument to the extension method or use 
 ```csharp
 .UseMaterialDynamicColors(options =>
 {
-    options.FallbackSeed = unchecked((int)0xFFB000B5);
+    options.FallbackSeed = 0xFFB000B5;
     options.UseDynamicColor = false;
 })
 ```
@@ -248,7 +248,7 @@ public class Scheme<TColor>
 
 This library uses "mappers" to turn `ColorPalette`s into `Scheme`s.
 ```csharp
-int seed = unchecked((int)0xFF5D5FDB);
+int seed = 0xFF5D5FDB;
 
 // Construct a CorePalette
 CorePalette corePalette = CorePalette.Of(seed);
@@ -329,7 +329,7 @@ public class MyCorePalette : CorePalette
     public MyCorePalette(int seed) : base(seed)
     {
         // You can harmonize a color to make it closer to the seed color
-        int harmonizedOrange = Blender.Harmonize(unchecked(0xFFA500), seed);
+        int harmonizedOrange = Blender.Harmonize(0xFFA500, seed);
         Orange = TonalPalette.FromInt(harmonizedOrange);
     }
 }


### PR DESCRIPTION
Pros:
- Don't have to write `unchecked((int)...)`, `uint argb = 0xFFFF_FFFF` is enough
- Easier to understand bitwise operations

Cons:
- Google uses ints, so it's harder to translate from the original implementation